### PR TITLE
Manual functional test workflow

### DIFF
--- a/.github/workflows/build-test-deploy-main.yml
+++ b/.github/workflows/build-test-deploy-main.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Run Unit Tests
         id: unittest
         run: npm run test
+      - name: Run Functional Tests
+        id: functionaltest
+        run: npm run test:examples
+        env:
+          browserstack_user: ${{ secrets.BROWSERSTACK_USER }}
+          browserstack_key: ${{ secrets.BROWSERSTACK_KEY }}
       - name: Update NPM Credentials File
         id: updatecredsfile
         run: cp .npmrc-publish ~/.npmrc

--- a/.github/workflows/build-test-pull-requests.yml
+++ b/.github/workflows/build-test-pull-requests.yml
@@ -20,14 +20,6 @@ jobs:
       - name: Check Circular Refs
         id: circularrefs
         run: npx dpdm -T --warning false **/index.ts
-      - name: Run Unit Tests
-        id: unittest
-        run: npm run test
-      - name: Functional Test
-        # only run functional tests on internal PRs
-        if: github.repository == 'bicarbon8/automated-functional-testing'
-        id: functionaltest
-        run: npm run test:examples
-        env:
-          browserstack_user: ${{ secrets.BROWSERSTACK_USER }}
-          browserstack_key: ${{ secrets.BROWSERSTACK_KEY }}
+      - name: Run Unit Tests with Coverage
+        id: unittestcov
+        run: npm run coverage

--- a/.github/workflows/run-test-examples.yml
+++ b/.github/workflows/run-test-examples.yml
@@ -1,0 +1,20 @@
+name: run-test-examples
+on: workflow_dispatch
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - name: Install Dependencies
+        id: installdeps
+        run: npm ci
+      - name: Run Example Test Projects
+        # only run functional tests on internal PRs
+        id: exampleprojecttests
+        run: npm run test:examples
+        env:
+          browserstack_user: ${{ secrets.BROWSERSTACK_USER }}
+          browserstack_key: ${{ secrets.BROWSERSTACK_KEY }}

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,5 @@ node_modules/
 dist/test/
 FileSystemMap/
 logs/
+coverage/
+.nyc_output/

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ await aftTest(description, (t: AftTest) => {
 - [`aft-ui`](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-ui/README.md) - base library supporting development of UI testing packages
 - [`aft-ui-selenium`](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-ui-selenium/README.md) - adds support for Selenium-based UI testing
 - [`aft-ui-webdriverio`](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-ui-webdriverio/README.md) - adds support for WebdriverIO-based UI testing
+- [`aft-vittest-reporter`](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-vitest-reporter/README.md) - provides Vitest Reporter plugin that integrates with AFT to simplify logging and test execution via AFT
 - [`aft-web-services`](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-web-services/README.md) - adds support for testing REST-based services
 
 ## Plugins

--- a/examples/selenium-jest/package.json
+++ b/examples/selenium-jest/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0",
-    "aft-jest-reporter": "^11.0.0",
-    "aft-jira": "^11.0.0",
-    "aft-reporting-aws-kinesis-firehose": "^11.0.0",
-    "aft-reporting-filesystem": "^11.0.0",
-    "aft-reporting-html": "^11.0.0",
-    "aft-testrail": "^11.0.0",
-    "aft-ui-selenium": "^11.0.0"
+    "aft-core": "^11.1.0",
+    "aft-jest-reporter": "^11.1.0",
+    "aft-jira": "^11.1.0",
+    "aft-reporting-aws-kinesis-firehose": "^11.1.0",
+    "aft-reporting-filesystem": "^11.1.0",
+    "aft-reporting-html": "^11.1.0",
+    "aft-testrail": "^11.1.0",
+    "aft-ui-selenium": "^11.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/examples/selenium-mocha/package.json
+++ b/examples/selenium-mocha/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0",
-    "aft-jira": "^11.0.0",
-    "aft-mocha-reporter": "^11.0.0",
-    "aft-reporting-aws-kinesis-firehose": "^11.0.0",
-    "aft-reporting-filesystem": "^11.0.0",
-    "aft-reporting-html": "^11.0.0",
-    "aft-testrail": "^11.0.0",
-    "aft-ui-selenium": "^11.0.0"
+    "aft-core": "^11.1.0",
+    "aft-jira": "^11.1.0",
+    "aft-mocha-reporter": "^11.1.0",
+    "aft-reporting-aws-kinesis-firehose": "^11.1.0",
+    "aft-reporting-filesystem": "^11.1.0",
+    "aft-reporting-html": "^11.1.0",
+    "aft-testrail": "^11.1.0",
+    "aft-ui-selenium": "^11.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.14",

--- a/examples/web-services-jasmine/package.json
+++ b/examples/web-services-jasmine/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0",
-    "aft-jasmine-reporter": "^11.0.0",
-    "aft-jira": "^11.0.0",
-    "aft-reporting-aws-kinesis-firehose": "^11.0.0",
-    "aft-reporting-filesystem": "^11.0.0",
-    "aft-reporting-html": "^11.0.0",
-    "aft-testrail": "^11.0.0",
-    "aft-web-services": "^11.0.0"
+    "aft-core": "^11.1.0",
+    "aft-jasmine-reporter": "^11.1.0",
+    "aft-jira": "^11.1.0",
+    "aft-reporting-aws-kinesis-firehose": "^11.1.0",
+    "aft-reporting-filesystem": "^11.1.0",
+    "aft-reporting-html": "^11.1.0",
+    "aft-testrail": "^11.1.0",
+    "aft-web-services": "^11.1.0"
   },
   "devDependencies": {
     "@types/jasmine": "^5.1.4",

--- a/examples/webdriverio-mocha/package.json
+++ b/examples/webdriverio-mocha/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0",
-    "aft-jira": "^11.0.0",
-    "aft-mocha-reporter": "^11.0.0",
-    "aft-reporting-aws-kinesis-firehose": "^11.0.0",
-    "aft-reporting-filesystem": "^11.0.0",
-    "aft-reporting-html": "^11.0.0",
-    "aft-testrail": "^11.0.0",
-    "aft-ui-webdriverio": "^11.0.0",
+    "aft-core": "^11.1.0",
+    "aft-jira": "^11.1.0",
+    "aft-mocha-reporter": "^11.1.0",
+    "aft-reporting-aws-kinesis-firehose": "^11.1.0",
+    "aft-reporting-filesystem": "^11.1.0",
+    "aft-reporting-html": "^11.1.0",
+    "aft-testrail": "^11.1.0",
+    "aft-ui-webdriverio": "^11.1.0",
     "webdriverio": "^8.35.1"
   },
   "devDependencies": {

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "11.0.0"
+  "version": "11.1.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,7 @@
 {
   "packages": [
-    "packages/*"
+    "packages/*",
+    "examples/*"
   ],
   "version": "11.1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,9 +587,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
-      "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+      "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -3713,6 +3713,43 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vitest/coverage-istanbul": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-1.5.0.tgz",
+      "integrity": "sha512-mEbVTIAPKhMkszO0lwOwWiG8Cvkj7rdMgdmCNUDnmcSZYUWGIqM8+4O1bcQ1WMHkejpcwvED5oU6ZFm3syVb6A==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-instrument": "^6.0.1",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.4",
+        "istanbul-reports": "^3.1.6",
+        "magicast": "^0.3.3",
+        "picocolors": "^1.0.0",
+        "test-exclude": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "1.5.0"
+      }
+    },
+    "node_modules/@vitest/coverage-istanbul/node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.4.tgz",
+      "integrity": "sha512-wHOoEsNJTVltaJp8eVkm8w+GVkVNHT2YDYo53YdzQEL2gWm1hBX5cGFR9hQJtuGLebidVX7et3+dmDZrmclduw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "1.5.0",
@@ -10914,6 +10951,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.4.tgz",
+      "integrity": "sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.24.4",
+        "@babel/types": "^7.24.0",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/make-dir": {
@@ -18412,6 +18460,7 @@
         "@types/node": "^20.11.30",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
+        "@vitest/coverage-istanbul": "^1.5.0",
         "aft-reporting-filesystem": "^11.1.0",
         "aft-reporting-html": "^11.1.0",
         "eslint": "^8.57.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,14 +18,14 @@
     "examples/selenium-jest": {
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0",
-        "aft-jest-reporter": "^11.0.0",
-        "aft-jira": "^11.0.0",
-        "aft-reporting-aws-kinesis-firehose": "^11.0.0",
-        "aft-reporting-filesystem": "^11.0.0",
-        "aft-reporting-html": "^11.0.0",
-        "aft-testrail": "^11.0.0",
-        "aft-ui-selenium": "^11.0.0"
+        "aft-core": "^11.1.0",
+        "aft-jest-reporter": "^11.1.0",
+        "aft-jira": "^11.1.0",
+        "aft-reporting-aws-kinesis-firehose": "^11.1.0",
+        "aft-reporting-filesystem": "^11.1.0",
+        "aft-reporting-html": "^11.1.0",
+        "aft-testrail": "^11.1.0",
+        "aft-ui-selenium": "^11.1.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -80,14 +80,14 @@
     "examples/selenium-mocha": {
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0",
-        "aft-jira": "^11.0.0",
-        "aft-mocha-reporter": "^11.0.0",
-        "aft-reporting-aws-kinesis-firehose": "^11.0.0",
-        "aft-reporting-filesystem": "^11.0.0",
-        "aft-reporting-html": "^11.0.0",
-        "aft-testrail": "^11.0.0",
-        "aft-ui-selenium": "^11.0.0"
+        "aft-core": "^11.1.0",
+        "aft-jira": "^11.1.0",
+        "aft-mocha-reporter": "^11.1.0",
+        "aft-reporting-aws-kinesis-firehose": "^11.1.0",
+        "aft-reporting-filesystem": "^11.1.0",
+        "aft-reporting-html": "^11.1.0",
+        "aft-testrail": "^11.1.0",
+        "aft-ui-selenium": "^11.1.0"
       },
       "devDependencies": {
         "@types/chai": "^4.3.14",
@@ -149,14 +149,14 @@
     "examples/web-services-jasmine": {
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0",
-        "aft-jasmine-reporter": "^11.0.0",
-        "aft-jira": "^11.0.0",
-        "aft-reporting-aws-kinesis-firehose": "^11.0.0",
-        "aft-reporting-filesystem": "^11.0.0",
-        "aft-reporting-html": "^11.0.0",
-        "aft-testrail": "^11.0.0",
-        "aft-web-services": "^11.0.0"
+        "aft-core": "^11.1.0",
+        "aft-jasmine-reporter": "^11.1.0",
+        "aft-jira": "^11.1.0",
+        "aft-reporting-aws-kinesis-firehose": "^11.1.0",
+        "aft-reporting-filesystem": "^11.1.0",
+        "aft-reporting-html": "^11.1.0",
+        "aft-testrail": "^11.1.0",
+        "aft-web-services": "^11.1.0"
       },
       "devDependencies": {
         "@types/jasmine": "^5.1.4",
@@ -194,14 +194,14 @@
     "examples/webdriverio-mocha": {
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0",
-        "aft-jira": "^11.0.0",
-        "aft-mocha-reporter": "^11.0.0",
-        "aft-reporting-aws-kinesis-firehose": "^11.0.0",
-        "aft-reporting-filesystem": "^11.0.0",
-        "aft-reporting-html": "^11.0.0",
-        "aft-testrail": "^11.0.0",
-        "aft-ui-webdriverio": "^11.0.0",
+        "aft-core": "^11.1.0",
+        "aft-jira": "^11.1.0",
+        "aft-mocha-reporter": "^11.1.0",
+        "aft-reporting-aws-kinesis-firehose": "^11.1.0",
+        "aft-reporting-filesystem": "^11.1.0",
+        "aft-reporting-html": "^11.1.0",
+        "aft-testrail": "^11.1.0",
+        "aft-ui-webdriverio": "^11.1.0",
         "webdriverio": "^8.35.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -833,6 +833,351 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2417,6 +2762,198 @@
         "node": ">=16.3.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.3.tgz",
+      "integrity": "sha512-X9alQ3XM6I9IlSlmC8ddAvMSyG1WuHk5oUnXGw+yUBs3BFoTizmG1La/Gr8fVJvDWAq+zlYTZ9DBgrlKRVY06g==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.3.tgz",
+      "integrity": "sha512-eQK5JIi+POhFpzk+LnjKIy4Ks+pwJ+NXmPxOCSvOKSNRPONzKuUvWE+P9JxGZVxrtzm6BAYMaL50FFuPe0oWMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.3.tgz",
+      "integrity": "sha512-Od4vE6f6CTT53yM1jgcLqNfItTsLt5zE46fdPaEmeFHvPs5SjZYlLpHrSiHEKR1+HdRfxuzXHjDOIxQyC3ptBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.3.tgz",
+      "integrity": "sha512-0IMAO21axJeNIrvS9lSe/PGthc8ZUS+zC53O0VhF5gMxfmcKAP4ESkKOCwEi6u2asUrt4mQv2rjY8QseIEb1aw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.3.tgz",
+      "integrity": "sha512-ge2DC7tHRHa3caVEoSbPRJpq7azhG+xYsd6u2MEnJ6XzPSzQsTKyXvh6iWjXRf7Rt9ykIUWHtl0Uz3T6yXPpKw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.14.3.tgz",
+      "integrity": "sha512-ljcuiDI4V3ySuc7eSk4lQ9wU8J8r8KrOUvB2U+TtK0TiW6OFDmJ+DdIjjwZHIw9CNxzbmXY39wwpzYuFDwNXuw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.3.tgz",
+      "integrity": "sha512-Eci2us9VTHm1eSyn5/eEpaC7eP/mp5n46gTRB3Aar3BgSvDQGJZuicyq6TsH4HngNBgVqC5sDYxOzTExSU+NjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.3.tgz",
+      "integrity": "sha512-UrBoMLCq4E92/LCqlh+blpqMz5h1tJttPIniwUgOFJyjWI1qrtrDhhpHPuFxULlUmjFHfloWdixtDhSxJt5iKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.3.tgz",
+      "integrity": "sha512-5aRjvsS8q1nWN8AoRfrq5+9IflC3P1leMoy4r2WjXyFqf3qcqsxRCfxtZIV58tCxd+Yv7WELPcO9mY9aeQyAmw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.3.tgz",
+      "integrity": "sha512-sk/Qh1j2/RJSX7FhEpJn8n0ndxy/uf0kI/9Zc4b1ELhqULVdTfN6HL31CDaTChiBAOgLcsJ1sgVZjWv8XNEsAQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.3.tgz",
+      "integrity": "sha512-jOO/PEaDitOmY9TgkxF/TQIjXySQe5KVYB57H/8LRP/ux0ZoO8cSHCX17asMSv3ruwslXW/TLBcxyaUzGRHcqg==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.3.tgz",
+      "integrity": "sha512-8ybV4Xjy59xLMyWo3GCfEGqtKV5M5gCSrZlxkPGvEPCGDLNla7v48S662HSGwRd6/2cSneMQWiv+QzcttLrrOA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.3.tgz",
+      "integrity": "sha512-s+xf1I46trOY10OqAtZ5Rm6lzHre/UiLA1J2uOhCFXWkbZrJRkYBPO6FhvGfHmdtQ3Bx793MNa7LvoWFAm93bg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.3.tgz",
+      "integrity": "sha512-+4h2WrGOYsOumDQ5S2sYNyhVfrue+9tc9XcLWLh+Kw3UOxAvrfOrSMFon60KspcDdytkNDh7K2Vs6eMaYImAZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.3.tgz",
+      "integrity": "sha512-T1l7y/bCeL/kUwh9OD4PQT4aM7Bq43vX05htPJJ46RTI4r5KNt6qJRzAfNfM+OYMNEVBWQzR2Gyk+FXLZfogGw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.3.tgz",
+      "integrity": "sha512-/BypzV0H1y1HzgYpxqRaXGBRqfodgoBBCcsrujT6QRcakDQdfU+Lq9PENPh5jB4I44YWq+0C2eHsHya+nZY1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sigstore/bundle": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-1.1.0.tgz",
@@ -2792,6 +3329,11 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.14.tgz",
       "integrity": "sha512-Wj71sXE4Q4AkGdG9Tvq1u/fquNz9EdG4LIJMwVVII7ashjD/8cf8fyIfJAjRr6YcsXnSE8cOGQPq1gqeR8z+3w==",
       "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/fs-ext": {
       "version": "2.0.3",
@@ -3181,6 +3723,95 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@vitest/expect": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.5.0.tgz",
+      "integrity": "sha512-0pzuCI6KYi2SIC3LQezmxujU9RK/vwC1U9R0rLuGlNGcOuDWxqWKu6nUdFsX9tH1WU0SXtAxToOsEjeUn1s3hA==",
+      "dependencies": {
+        "@vitest/spy": "1.5.0",
+        "@vitest/utils": "1.5.0",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.5.0.tgz",
+      "integrity": "sha512-7HWwdxXP5yDoe7DTpbif9l6ZmDwCzcSIK38kTSIt6CFEpMjX4EpCgT6wUmS0xTXqMI6E/ONmfgRKmaujpabjZQ==",
+      "dependencies": {
+        "@vitest/utils": "1.5.0",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.5.0.tgz",
+      "integrity": "sha512-qpv3fSEuNrhAO3FpH6YYRdaECnnRjg9VxbhdtPwPRnzSfHVXnNzzrpX4cJxqiwgRMo7uRMWDFBlsBq4Cr+rO3A==",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.5.0.tgz",
+      "integrity": "sha512-vu6vi6ew5N5MMHJjD5PoakMRKYdmIrNJmyfkhRpQt5d9Ewhw9nZ5Aqynbi3N61bvk9UvZ5UysMT6ayIrZ8GA9w==",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.5.0.tgz",
+      "integrity": "sha512-BDU0GNL8MWkRkSRdNFvCUCAVOeHaUlVJ9Tx0TYBZyXaaOTmGtUFObzchCivIBrIwKzvZA7A9sCejVhXM2aY98A==",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@wdio/config": {
       "version": "8.35.0",
       "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.35.0.tgz",
@@ -3394,7 +4025,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "devOptional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3415,7 +4045,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3472,6 +4101,10 @@
     },
     "node_modules/aft-ui-webdriverio": {
       "resolved": "packages/aft-ui-webdriverio",
+      "link": true
+    },
+    "node_modules/aft-vitest-reporter": {
+      "resolved": "packages/aft-vitest-reporter",
       "link": true
     },
     "node_modules/aft-web-services": {
@@ -3881,7 +4514,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -4337,6 +4969,14 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cacache": {
       "version": "16.1.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
@@ -4648,7 +5288,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
       "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
-      "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -4706,7 +5345,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
       "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.2"
       },
@@ -5596,7 +6234,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
       "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "dev": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -6125,6 +6762,43 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
+    "node_modules/esbuild": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
@@ -6449,6 +7123,14 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/esutils": {
@@ -7358,7 +8040,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -9520,8 +10201,7 @@
     "node_modules/jsonc-parser": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -10095,6 +10775,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/local-pkg": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+      "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+      "dependencies": {
+        "mlly": "^1.4.2",
+        "pkg-types": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-app": {
       "version": "2.2.25",
       "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.2.25.tgz",
@@ -10202,7 +10897,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
       "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
@@ -10231,6 +10925,17 @@
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.9.tgz",
+      "integrity": "sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -10805,6 +11510,17 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
+    "node_modules/mlly": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.6.1.tgz",
+      "integrity": "sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==",
+      "dependencies": {
+        "acorn": "^8.11.3",
+        "pathe": "^1.1.2",
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.3.2"
+      }
+    },
     "node_modules/mocha": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.3.0.tgz",
@@ -11108,6 +11824,23 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
       "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -12995,11 +13728,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
+    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -13056,12 +13793,49 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
+      "dependencies": {
+        "jsonc-parser": "^3.2.0",
+        "mlly": "^1.2.0",
+        "pathe": "^1.1.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -14135,6 +14909,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.3.tgz",
+      "integrity": "sha512-ag5tTQKYsj1bhrFC9+OEWqb5O6VYgtQDO9hPDBMmIbePwhfSr+ExlcU741t8Dhw5DkPCQf6noz0jb36D6W9/hw==",
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.14.3",
+        "@rollup/rollup-android-arm64": "4.14.3",
+        "@rollup/rollup-darwin-arm64": "4.14.3",
+        "@rollup/rollup-darwin-x64": "4.14.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.14.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.14.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.14.3",
+        "@rollup/rollup-linux-arm64-musl": "4.14.3",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.14.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-musl": "4.14.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.14.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.14.3",
+        "@rollup/rollup-win32-x64-msvc": "4.14.3",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -14364,6 +15172,11 @@
         "vscode-oniguruma": "^1.7.0",
         "vscode-textmate": "^8.0.0"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -14636,6 +15449,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -14870,6 +15691,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
+    },
+    "node_modules/std-env": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg=="
+    },
     "node_modules/streamx": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
@@ -15047,6 +15878,22 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.0.tgz",
+      "integrity": "sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==",
+      "dependencies": {
+        "js-tokens": "^9.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.0.tgz",
+      "integrity": "sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ=="
     },
     "node_modules/strong-log-transformer": {
       "version": "2.1.0",
@@ -15277,6 +16124,27 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.7.0.tgz",
+      "integrity": "sha512-Qgayeb106x2o4hNzNjsZEfFziw8IbKqtbXBjVh7VIZfBxfD5M4gWtpyx5+YTae2gJ6Y6Dz/KLepiv16RFeQWNA=="
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -15772,6 +16640,11 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz",
+      "integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw=="
+    },
     "node_modules/uglify-js": {
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
@@ -16054,6 +16927,258 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/vite": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.9.tgz",
+      "integrity": "sha512-uOQWfuZBlc6Y3W/DTuQ1Sr+oIXWvqljLvS881SVmAj00d5RdgShLcuXWxseWPd4HXwiYBFW/vXHfKFeqj9uQnw==",
+      "dependencies": {
+        "esbuild": "^0.20.1",
+        "postcss": "^8.4.38",
+        "rollup": "^4.13.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.5.0.tgz",
+      "integrity": "sha512-tV8h6gMj6vPzVCa7l+VGq9lwoJjW8Y79vst8QZZGiuRAfijU+EEWuc0kFpmndQrWhMMhet1jdSF+40KSZUqIIw==",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.5.0.tgz",
+      "integrity": "sha512-d8UKgR0m2kjdxDWX6911uwxout6GHS0XaGH1cksSIVVG8kRlE7G7aBw7myKQCvDI5dT4j7ZMa+l706BIORMDLw==",
+      "dependencies": {
+        "@vitest/expect": "1.5.0",
+        "@vitest/runner": "1.5.0",
+        "@vitest/snapshot": "1.5.0",
+        "@vitest/spy": "1.5.0",
+        "@vitest/utils": "1.5.0",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.5.0",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.5.0",
+        "@vitest/ui": "1.5.0",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/vitest/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/vitest/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
@@ -16239,6 +17364,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {
@@ -17272,6 +18412,43 @@
       }
     },
     "packages/aft-ui/node_modules/rimraf": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
+      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/aft-vitest-reporter": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "aft-core": "^11.0.0",
+        "vitest": "^1.5.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "@typescript-eslint/eslint-plugin": "^7.4.0",
+        "@typescript-eslint/parser": "^7.4.0",
+        "aft-reporting-filesystem": "^11.0.0",
+        "aft-reporting-html": "^11.0.0",
+        "eslint": "^8.57.0",
+        "nyc": "^15.1.0",
+        "rimraf": "^5.0.1",
+        "typescript": "^5.1.6"
+      }
+    },
+    "packages/aft-vitest-reporter/node_modules/rimraf": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
       "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17908,7 +17908,7 @@
       }
     },
     "packages/aft-core": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
         "colors": "^1.4.0",
@@ -17978,10 +17978,10 @@
       }
     },
     "packages/aft-jasmine-reporter": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0",
+        "aft-core": "^11.1.0",
         "jasmine": "^5.1.0"
       },
       "devDependencies": {
@@ -17989,8 +17989,8 @@
         "@types/node": "^20.11.30",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
-        "aft-reporting-filesystem": "^11.0.0",
-        "aft-reporting-html": "^11.0.0",
+        "aft-reporting-filesystem": "^11.1.0",
+        "aft-reporting-html": "^11.1.0",
         "eslint": "^8.57.0",
         "nyc": "^15.1.0",
         "rimraf": "^5.0.1",
@@ -18017,10 +18017,10 @@
       }
     },
     "packages/aft-jest-reporter": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0",
+        "aft-core": "^11.1.0",
         "jest": "^29.7.0"
       },
       "devDependencies": {
@@ -18029,8 +18029,8 @@
         "@types/node": "^20.11.30",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
-        "aft-reporting-filesystem": "^11.0.0",
-        "aft-reporting-html": "^11.0.0",
+        "aft-reporting-filesystem": "^11.1.0",
+        "aft-reporting-html": "^11.1.0",
         "eslint": "^8.57.0",
         "nyc": "^15.1.0",
         "rimraf": "^5.0.1",
@@ -18057,10 +18057,10 @@
       }
     },
     "packages/aft-jira": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-web-services": "^11.0.0"
+        "aft-web-services": "^11.1.0"
       },
       "devDependencies": {
         "@types/jasmine": "^4.6.4",
@@ -18094,10 +18094,10 @@
       }
     },
     "packages/aft-mocha-reporter": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0",
+        "aft-core": "^11.1.0",
         "mocha": "^10.3.0"
       },
       "devDependencies": {
@@ -18106,8 +18106,8 @@
         "@types/sinon": "^10.0.20",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
-        "aft-reporting-filesystem": "^11.0.0",
-        "aft-reporting-html": "^11.0.0",
+        "aft-reporting-filesystem": "^11.1.0",
+        "aft-reporting-html": "^11.1.0",
         "chai": "^4.4.1",
         "eslint": "^8.57.0",
         "nyc": "^15.1.0",
@@ -18136,10 +18136,10 @@
       }
     },
     "packages/aft-reporting-aws-kinesis-firehose": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0",
+        "aft-core": "^11.1.0",
         "aws-sdk": "^2.1584.0"
       },
       "devDependencies": {
@@ -18175,10 +18175,10 @@
       }
     },
     "packages/aft-reporting-filesystem": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0",
+        "aft-core": "^11.1.0",
         "date-and-time": "^3.1.1"
       },
       "devDependencies": {
@@ -18213,10 +18213,10 @@
       }
     },
     "packages/aft-reporting-html": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0"
+        "aft-core": "^11.1.0"
       },
       "devDependencies": {
         "@types/jasmine": "^4.6.4",
@@ -18250,10 +18250,10 @@
       }
     },
     "packages/aft-testrail": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-web-services": "^11.0.0"
+        "aft-web-services": "^11.1.0"
       },
       "devDependencies": {
         "@types/jasmine": "^4.6.4",
@@ -18287,10 +18287,10 @@
       }
     },
     "packages/aft-ui": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0"
+        "aft-core": "^11.1.0"
       },
       "devDependencies": {
         "@types/jasmine": "^4.6.4",
@@ -18306,10 +18306,10 @@
       }
     },
     "packages/aft-ui-selenium": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-ui": "^11.0.0",
+        "aft-ui": "^11.1.0",
         "selenium-webdriver": "^4.18.1"
       },
       "devDependencies": {
@@ -18346,10 +18346,10 @@
       }
     },
     "packages/aft-ui-webdriverio": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-ui": "^11.0.0",
+        "aft-ui": "^11.1.0",
         "webdriverio": "^8.35.1"
       },
       "devDependencies": {
@@ -18402,18 +18402,18 @@
       }
     },
     "packages/aft-vitest-reporter": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0",
+        "aft-core": "^11.1.0",
         "vitest": "^1.5.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.30",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
-        "aft-reporting-filesystem": "^11.0.0",
-        "aft-reporting-html": "^11.0.0",
+        "aft-reporting-filesystem": "^11.1.0",
+        "aft-reporting-html": "^11.1.0",
         "eslint": "^8.57.0",
         "nyc": "^15.1.0",
         "rimraf": "^5.0.1",
@@ -18439,10 +18439,10 @@
       }
     },
     "packages/aft-web-services": {
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^11.0.0",
+        "aft-core": "^11.1.0",
         "form-data": "^4.0.0",
         "xmldoc": "^1.3.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3335,15 +3335,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
-    "node_modules/@types/fs-ext": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/fs-ext/-/fs-ext-2.0.3.tgz",
-      "integrity": "sha512-0j2F+laosJF2NTd2DVheQ5GvXo8ln9L175VwLPfbsppE33iYC+6gn6XlOQS0pGvZm2yrQ32/LRZh0As/7rCs2Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -7660,18 +7651,6 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
-    "node_modules/fs-ext": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fs-ext/-/fs-ext-2.0.0.tgz",
-      "integrity": "sha512-aK8NlpSO5LUdSoWeshpnkgtptbua1rGo58Wc+mHQ2+JnoBlubMTsnV56Swl4bA0msrgAhG8TDu1aGS8deJwzBQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "nan": "^2.14.0"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/fs-extra": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
@@ -11819,11 +11798,6 @@
       "version": "1.8.28",
       "resolved": "https://registry.npmjs.org/n12/-/n12-1.8.28.tgz",
       "integrity": "sha512-d7AxSTy3yrAT//gLFd7s/m4bNGQsiFKah1c/YBw85IvrCvoQZpqaAhnC7ANtjW1C7SE5SiT97Y2H21LCzS9qbA=="
-    },
-    "node_modules/nan": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
-      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw=="
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -17939,12 +17913,10 @@
       "dependencies": {
         "colors": "^1.4.0",
         "dotenv": "^16.4.5",
-        "fs-ext": "^2.0.0",
         "lodash": "^4.17.21",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@types/fs-ext": "^2.0.3",
         "@types/jasmine": "^4.6.4",
         "@types/node": "^20.11.30",
         "@types/uuid": "^9.0.8",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:mocha": "npm run test --workspace=aft-mocha-reporter",
     "test:jasmine": "npm run test --workspace=aft-jasmine-reporter",
     "test:jest": "npm run test --workspace=aft-jest-reporter",
+    "test:vitest": "npm run test --workspace=aft-vitest-reporter",
     "docs": "npm run build && typedoc",
     "circular": "npx dpdm -T --warning false **/index.ts"
   },

--- a/packages/aft-core/README.md
+++ b/packages/aft-core/README.md
@@ -172,9 +172,9 @@ export class TestRailPolicyPlugin extends PolicyPlugin {
 
 ## Integration with javascript test frameworks
 the `aft-core` package comes with an `AftTest` class which can be extended from to allow near seamless integration of AFT's reporting and test execution flow control features. AFT already has packages for integration with a few of the major test frameworks such as Jasmine, Mocha and Jest and these can be used as examples for implementing your own as needed if you are using some other test framework _(NOTE: the Mocha integration also works with Cypress)_. 
-- `aft-jasmine-reporter`: [aft-test](../aft-jasmine-reporter/README.md#aftjasminetest)
-- `aft-mocha-reporter`: [aft-test](../aft-mocha-reporter/README.md#aftmochatest)
-- `aft-jest-reporter`: [aft-test](../aft-jest-reporter/README.md#aftjesttest)
+- `aft-jasmine-reporter`: [aft-jasmine-test](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-jasmine-reporter/README.md#aftjasminetest)
+- `aft-mocha-reporter`: [aft-mocha-test](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-mocha-reporter/README.md#aftmochatest)
+- `aft-jest-reporter`: [aft-jest-test](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-jest-reporter/README.md#aftjesttest)
 
 ## Testing with AftTest
 the `AftTest` class and `AftTest.verify` functions of `aft-core` enable testing with pre-execution filtering based on integration with external test execution policy managers via plugin packages extending the `PolicyPlugin` class (see examples above).

--- a/packages/aft-core/README.md
+++ b/packages/aft-core/README.md
@@ -175,6 +175,7 @@ the `aft-core` package comes with an `AftTest` class which can be extended from 
 - `aft-jasmine-reporter`: [aft-jasmine-test](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-jasmine-reporter/README.md#aftjasminetest)
 - `aft-mocha-reporter`: [aft-mocha-test](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-mocha-reporter/README.md#aftmochatest)
 - `aft-jest-reporter`: [aft-jest-test](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-jest-reporter/README.md#aftjesttest)
+- `aft-vitest-reporter`: [aft-vitest-test](https://github.com/bicarbon8/automated-functional-testing/blob/main/packages/aft-vitest-reporter/README.md#aftvitesttest)
 
 ## Testing with AftTest
 the `AftTest` class and `AftTest.verify` functions of `aft-core` enable testing with pre-execution filtering based on integration with external test execution policy managers via plugin packages extending the `PolicyPlugin` class (see examples above).
@@ -188,6 +189,7 @@ describe('Sample Test', () => {
          * - for Jest use: `const aft = new AftJestTest(expect);`
          * - for Mocha use: `const aft = new AftMochaTest(this);`
          * - for Jasmine use: `const aft = new AftJasmineTest();`
+         * - for Vitest use: `const aft = new AftVitTestTest(ctx);`
          */
         await aftJasmineTest(async (t: AftJasmineTest) => {
             /**

--- a/packages/aft-core/package.json
+++ b/packages/aft-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-core",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automation Framework for Testing (AFT) package supporting JavaScript unit, integration and functional testing",
   "repository": {
     "type": "git",

--- a/packages/aft-core/package.json
+++ b/packages/aft-core/package.json
@@ -32,12 +32,10 @@
   "dependencies": {
     "colors": "^1.4.0",
     "dotenv": "^16.4.5",
-    "fs-ext": "^2.0.0",
     "lodash": "^4.17.21",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@types/fs-ext": "^2.0.3",
     "@types/jasmine": "^4.6.4",
     "@types/node": "^20.11.30",
     "@types/uuid": "^9.0.8",

--- a/packages/aft-core/src/helpers/expiring-file-lock.ts
+++ b/packages/aft-core/src/helpers/expiring-file-lock.ts
@@ -1,10 +1,10 @@
-import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { safeFlock } from "./safe-flock";
+import { SafeFlock } from "./safe-flock";
 import { convert } from "./convert";
 import { ellide } from "./ellide";
 import { AftConfig, aftConfig } from "../configuration/aft-config";
+import { Err } from "./err";
 
 /**
  * class will create a new (or use existing) lockfile locking 
@@ -18,8 +18,8 @@ import { AftConfig, aftConfig } from "../configuration/aft-config";
  * ```json
  * // aftconfig.json
  * {
- *     fileLockMaxWait: 10000,
- *     fileLockMaxHold: 5000
+ *     "fileLockMaxWait": 10000,
+ *     "fileLockMaxHold": 5000
  * }
  * ```
  * ```typescript
@@ -39,9 +39,10 @@ export class ExpiringFileLock {
     public readonly lockDuration: number;
     public readonly waitDuration: number;
 
-    private readonly _lockFileDescriptor: number;
-    private readonly _timeout: NodeJS.Timeout; // eslint-disable-line no-undef
-    
+    private readonly _safeFlock: SafeFlock;
+
+    private _timeout: NodeJS.Timeout; // eslint-disable-line no-undef
+
     constructor(lockFileName: string, aftCfg?: AftConfig) {
         if (!lockFileName) {
             throw new Error(`[${this.constructor.name}] - lockFileName must be set`);
@@ -50,8 +51,8 @@ export class ExpiringFileLock {
         this.lockDuration = Math.abs(this.aftCfg.fileLockMaxHold ?? 10000); // ensure positive value; defaults to 10 s
         this.waitDuration = Math.abs(this.aftCfg.fileLockMaxWait ?? 10000); // ensure positive value; defaults to 10 s
         this.lockName = path.join(os.tmpdir(), ellide(convert.toSafeString(lockFileName), 255, 'beginning', ''));
-        this._lockFileDescriptor = this._waitForLock();
-        this._timeout = setTimeout(() => safeFlock.get(this._lockFileDescriptor, 'un'), this.lockDuration); // eslint-disable-line no-undef
+        this._safeFlock = new SafeFlock(this.lockName);
+        this._waitForLock();
     }
 
     /**
@@ -59,35 +60,36 @@ export class ExpiringFileLock {
      * timer
      */
     unlock(): void {
-        clearTimeout(this._timeout); // eslint-disable-line no-undef
-        safeFlock.get(this._lockFileDescriptor, 'un');
+        try {
+            this._safeFlock.unlock();
+        } catch {
+            /* ignore */
+        }
+        if (this._timeout) {
+            try {
+                clearTimeout(this._timeout); // eslint-disable-line no-undef
+            } catch {
+                /* ignore */
+            }
+        }
     }
 
-    private _waitForLock(): number {
-        const startTime: number = new Date().getTime();
-        let haveLock: boolean = false;
-        let lockFileDescriptor: number;
-        while (!haveLock && convert.toElapsedMs(startTime) < this.waitDuration) {
-            if (!lockFileDescriptor) {
-                try {
-                    lockFileDescriptor = fs.openSync(this.lockName, 'w');
-                } catch (e) {
-                    /* ignore */
-                }
-            }
-            if (lockFileDescriptor) {
-                try {
-                    safeFlock.get(lockFileDescriptor, 'ex');
-                    haveLock = true;
-                } catch (e) {
-                    /* ignore */
-                }
+    private _waitForLock(): void {
+        const startTime: number = Date.now();
+        let err: Error;
+        let haveLock = false;
+        while (haveLock !== true && convert.toElapsedMs(startTime) < this.waitDuration) {
+            try {
+                this._safeFlock.lock();
+                haveLock = true;
+                this._timeout = setTimeout(() => this.unlock(), this.lockDuration); // eslint-disable-line no-undef
+            } catch (e) {
+                err = e;
             }
         }
-        if (!lockFileDescriptor) {
-            throw new Error(`unable to acquire lock on '${this.lockName}' within '${this.waitDuration}ms'`);
+        if (haveLock !== true) {
+            throw new Error(`unable to acquire lock on '${this.lockName}' within '${this.waitDuration}ms' due to: ${Err.full(err)}`);
         }
-        return lockFileDescriptor;
     }
 
     /**

--- a/packages/aft-core/src/helpers/file-io.ts
+++ b/packages/aft-core/src/helpers/file-io.ts
@@ -77,7 +77,7 @@ export class FileIO {
             file = fs.realpathSync(path.join(process.cwd(), file));
         }
         if (fs.statSync(file).isDirectory()) {
-            throw `[fileio.readAs<T>] expected filename but received directory instead: ${file}`;
+            throw new Error(`[fileio.readAs<T>] expected filename but received directory instead: ${file}`);
         }
         const fd: number = fs.openSync(file, 'rs+');
         let fileContents: string;

--- a/packages/aft-core/src/helpers/safe-flock.ts
+++ b/packages/aft-core/src/helpers/safe-flock.ts
@@ -1,16 +1,12 @@
 import * as fs from "node:fs";
 import { AftLogger } from "../logging/aft-logger";
-import { Err } from "./err";
 import { rand } from "./rand";
-
-type FlockFlags = 'ex' | 'un' | "sh" | "shnb" | "exnb";
-type FlockFunction = (fn: number, flags: FlockFlags) => void; // eslint-disable-line no-unused-vars
+import { AftConfig } from "../configuration/aft-config";
 
 /**
- * provides an execution environment agnostic way of loading the
- * `flockSync` functionality from the `fs-ext` package to avoid
- * a `Module did not self-register: ...fs-ext.node` error. usage
- * is as follows:
+ * provides an execution environment agnostic way of creating
+ * an exclusive lock when running across multiple node processes
+ * usage is as follows:
  * ```typescript
  * // get exclusive file lock or throw error
  * const sflock = new SafeFlock(file).lock();
@@ -22,67 +18,29 @@ type FlockFunction = (fn: number, flags: FlockFlags) => void; // eslint-disable-
  * > this should _NOT_ be exported from AFT
  */
 export class SafeFlock {
-    private readonly _flockSync: FlockFunction;
     private readonly _logger: AftLogger;
     private readonly _id: string;
     private readonly _file: string;
 
-    private _fd: number;
+    private _locked: boolean;
 
-    constructor(file: string) {
+    constructor(file: string, aftCfg?: AftConfig) {
         this._id = rand.guid;
-        this._logger = new AftLogger(this.constructor.name);
-        try {
-            // const fse = require("fs-ext"); // eslint-disable-line no-undef
-            // this._flockSync = fse.flockSync;
-        } catch (e) {
-            this._logger.log({
-                level: 'warn',
-                message: `unable to load 'fs-ext.flockSync' due to: ${Err.full(e)}\ncontinuing without file locks`
-            });
-        }
+        this._logger = new AftLogger(this.constructor.name, aftCfg);
         this._file = file;
+        this._locked = false;
+    }
+
+    get locked(): boolean {
+        return this._locked === true;
     }
 
     /**
      * places an exclusive lock on the given `file` file if possible and
      * throws error otherwise
-     * @returns a reference to `this` instance
+     * @returns this instance for command chaining
      */
     lock(): this {
-        let fd: number;
-        if (this._flockSync) {
-            fd = fs.openSync(this._file, 'w');
-            this._flockSync(fd, 'ex');
-            this._fd = fd;
-        } else {
-            this._fallbackLock()
-        }
-        return this;
-    }
-
-    /**
-     * releases the lock if this instance owns it otherwise throws an
-     * error
-     * @returns a reference to `this` instance
-     */
-    unlock(): this {
-        if (this._flockSync) {
-            try {
-                this._flockSync(this._fd, 'un');
-            } finally {
-                if (this._fd) {
-                    fs.closeSync(this._fd);
-                    this._fd = null;
-                }
-            }
-        } else {
-            this._fallbackUnlock();
-        }
-        return this;
-    }
-
-    private _fallbackLock(): void {
         // open for read and append and create if not already exists
         if (!fs.existsSync(this._file)) {
             fs.writeFileSync(this._file, this._id, {encoding: 'utf-8'});
@@ -90,31 +48,33 @@ export class SafeFlock {
         const contents: string = fs.readFileSync(this._file, {encoding: 'utf-8'});
         if (contents == null || contents === '') {
             fs.writeFileSync(this._file, this._id, {encoding: 'utf-8'});
-            this._fallbackLock(); // ensure we have lock
+            this.lock(); // ensure we have lock
         } else if (contents === this._id) {
             /* we already have lock */
-            this._logger.log({level: 'debug', message: 'successfully locked'});
+            this._locked = true;
+            this._logger.log({level: 'trace', message: 'successfully locked'});
         } else {
             throw new Error(`file '${this._file}' is already locked by someone else`);
         }
+        return this;
     }
 
-    private _fallbackUnlock(): void {
-        try {
-            const contents: string = fs.readFileSync(this._file, {encoding: 'utf-8'});
-            if (contents === this._id) {
-                fs.writeFileSync(this._file, '', {encoding: 'utf-8'});
-                this._fallbackUnlock(); // ensure unlocked
-            } else if (contents == null || contents === '') {
-                /* we already unlocked */
-                this._logger.log({level: 'debug', message: 'successfully unlocked'});
-            } else {
-                throw new Error(`unable to unlock '${this._file}' because we are not the owner of the lock`);
-            }
-        } finally {
-            if (this._fd) {
-                this._fd = null;
-            }
+    /**
+     * releases the lock if this instance owns it otherwise throws an
+     * error
+     * @returns this instance for command chaining
+     */
+    unlock(): this {
+        const contents: string = fs.readFileSync(this._file, {encoding: 'utf-8'});
+        if (contents === this._id) {
+            fs.writeFileSync(this._file, '', {encoding: 'utf-8'});
+            this.unlock(); // ensure unlocked
+        } else if (contents == null || contents === '') {
+            /* we already unlocked */
+            this._logger.log({level: 'trace', message: 'successfully unlocked'});
+        } else {
+            throw new Error(`unable to unlock '${this._file}' because we are not the owner of the lock`);
         }
+        return this;
     }
 }

--- a/packages/aft-core/src/helpers/safe-flock.ts
+++ b/packages/aft-core/src/helpers/safe-flock.ts
@@ -1,52 +1,120 @@
+import * as fs from "node:fs";
 import { AftLogger } from "../logging/aft-logger";
 import { Err } from "./err";
+import { rand } from "./rand";
 
 type FlockFlags = 'ex' | 'un' | "sh" | "shnb" | "exnb";
-type FlockFunction = (fn: number, flags: FlockFlags) => void;
-
-class SafeFlock {
-    private readonly _flockSync: FlockFunction;
-    private readonly _logger: AftLogger;
-
-    constructor() {
-        this._logger = new AftLogger(this.constructor.name);
-        try {
-            const fse = require("fs-ext");
-            this._flockSync = fse.flockSync;
-        } catch (e) {
-            this._flockSync = (fn: number, flags: FlockFlags) => { /* do nothing */ }; // eslint-disable-line no-unused-vars
-            this._logger.log({
-                level: 'warn',
-                message: `unable to load 'fs-ext.flockSync' due to: ${Err.full(e)}\ncontinuing without file locks`
-            });
-        }
-    }
-
-    /**
-     * performs a specified action against a file such as waiting for an exclusive
-     * lock or releasing a lock based on the passed in `fd` and `flag`
-     * @param fd a file descriptor number returned from a call like `fs.openSync(...)`
-     * @param flag a string indicating what action to perform agains the file where
-     * `ex` waits for an exclusive lock and `un` releases the lock
-     */
-    get(fd: number, flag: FlockFlags): void {
-        this._flockSync(fd, flag);
-    }
-}
+type FlockFunction = (fn: number, flags: FlockFlags) => void; // eslint-disable-line no-unused-vars
 
 /**
  * provides an execution environment agnostic way of loading the
  * `flockSync` functionality from the `fs-ext` package to avoid
  * a `Module did not self-register: ...fs-ext.node` error. usage
- * is exactly like calling `flockSync`:
+ * is as follows:
  * ```typescript
- * // wait for exclusive file lock
- * safeFlock.get(fileDescriptor, 'ex');
+ * // get exclusive file lock or throw error
+ * const sflock = new SafeFlock(file).lock();
  * 
  * // release file lock
- * safeFlock.get(fileDescriptor, 'un');
+ * sflock.unlock();
  * ```
  * **NOTE**
  * > this should _NOT_ be exported from AFT
  */
-export const safeFlock = new SafeFlock();
+export class SafeFlock {
+    private readonly _flockSync: FlockFunction;
+    private readonly _logger: AftLogger;
+    private readonly _id: string;
+    private readonly _file: string;
+
+    private _fd: number;
+
+    constructor(file: string) {
+        this._id = rand.guid;
+        this._logger = new AftLogger(this.constructor.name);
+        try {
+            // const fse = require("fs-ext"); // eslint-disable-line no-undef
+            // this._flockSync = fse.flockSync;
+        } catch (e) {
+            this._logger.log({
+                level: 'warn',
+                message: `unable to load 'fs-ext.flockSync' due to: ${Err.full(e)}\ncontinuing without file locks`
+            });
+        }
+        this._file = file;
+    }
+
+    /**
+     * places an exclusive lock on the given `file` file if possible and
+     * throws error otherwise
+     * @returns a reference to `this` instance
+     */
+    lock(): this {
+        let fd: number;
+        if (this._flockSync) {
+            fd = fs.openSync(this._file, 'w');
+            this._flockSync(fd, 'ex');
+            this._fd = fd;
+        } else {
+            this._fallbackLock()
+        }
+        return this;
+    }
+
+    /**
+     * releases the lock if this instance owns it otherwise throws an
+     * error
+     * @returns a reference to `this` instance
+     */
+    unlock(): this {
+        if (this._flockSync) {
+            try {
+                this._flockSync(this._fd, 'un');
+            } finally {
+                if (this._fd) {
+                    fs.closeSync(this._fd);
+                    this._fd = null;
+                }
+            }
+        } else {
+            this._fallbackUnlock();
+        }
+        return this;
+    }
+
+    private _fallbackLock(): void {
+        // open for read and append and create if not already exists
+        if (!fs.existsSync(this._file)) {
+            fs.writeFileSync(this._file, this._id, {encoding: 'utf-8'});
+        }
+        const contents: string = fs.readFileSync(this._file, {encoding: 'utf-8'});
+        if (contents == null || contents === '') {
+            fs.writeFileSync(this._file, this._id, {encoding: 'utf-8'});
+            this._fallbackLock(); // ensure we have lock
+        } else if (contents === this._id) {
+            /* we already have lock */
+            this._logger.log({level: 'debug', message: 'successfully locked'});
+        } else {
+            throw new Error(`file '${this._file}' is already locked by someone else`);
+        }
+    }
+
+    private _fallbackUnlock(): void {
+        try {
+            const contents: string = fs.readFileSync(this._file, {encoding: 'utf-8'});
+            if (contents === this._id) {
+                fs.writeFileSync(this._file, '', {encoding: 'utf-8'});
+                this._fallbackUnlock(); // ensure unlocked
+            } else if (contents == null || contents === '') {
+                /* we already unlocked */
+                this._logger.log({level: 'debug', message: 'successfully unlocked'});
+            } else {
+                throw new Error(`unable to unlock '${this._file}' because we are not the owner of the lock`);
+            }
+        } finally {
+            if (this._fd) {
+                this._fd = null;
+            }
+        }
+    }
+}

--- a/packages/aft-core/src/helpers/safe-flock.ts
+++ b/packages/aft-core/src/helpers/safe-flock.ts
@@ -1,0 +1,52 @@
+import { AftLogger } from "../logging/aft-logger";
+import { Err } from "./err";
+
+type FlockFlags = 'ex' | 'un' | "sh" | "shnb" | "exnb";
+type FlockFunction = (fn: number, flags: FlockFlags) => void;
+
+class SafeFlock {
+    private readonly _flockSync: FlockFunction;
+    private readonly _logger: AftLogger;
+
+    constructor() {
+        this._logger = new AftLogger(this.constructor.name);
+        try {
+            const fse = require("fs-ext");
+            this._flockSync = fse.flockSync;
+        } catch (e) {
+            this._flockSync = (fn: number, flags: FlockFlags) => { /* do nothing */ }; // eslint-disable-line no-unused-vars
+            this._logger.log({
+                level: 'warn',
+                message: `unable to load 'fs-ext.flockSync' due to: ${Err.full(e)}\ncontinuing without file locks`
+            });
+        }
+    }
+
+    /**
+     * performs a specified action against a file such as waiting for an exclusive
+     * lock or releasing a lock based on the passed in `fd` and `flag`
+     * @param fd a file descriptor number returned from a call like `fs.openSync(...)`
+     * @param flag a string indicating what action to perform agains the file where
+     * `ex` waits for an exclusive lock and `un` releases the lock
+     */
+    get(fd: number, flag: FlockFlags): void {
+        this._flockSync(fd, flag);
+    }
+}
+
+/**
+ * provides an execution environment agnostic way of loading the
+ * `flockSync` functionality from the `fs-ext` package to avoid
+ * a `Module did not self-register: ...fs-ext.node` error. usage
+ * is exactly like calling `flockSync`:
+ * ```typescript
+ * // wait for exclusive file lock
+ * safeFlock.get(fileDescriptor, 'ex');
+ * 
+ * // release file lock
+ * safeFlock.get(fileDescriptor, 'un');
+ * ```
+ * **NOTE**
+ * > this should _NOT_ be exported from AFT
+ */
+export const safeFlock = new SafeFlock();

--- a/packages/aft-core/src/logging/aft-logger.ts
+++ b/packages/aft-core/src/logging/aft-logger.ts
@@ -40,7 +40,7 @@ export class AftLogger {
      * allows for filtering out of erroneous information from logs by assigning
      * values to different types of logging. the purpose of each log level is
      * as follows:
-     * - `trace` - used when logging low-level debug events that occur within a loop
+     * - `trace` - used by AFT internal systems or debug events that would be very chatty (for ex: occur within a loop)
      * - `debug` - used for debug logging that does not run within a loop or at a high frequency
      * - `info` - used for informational events providing current state of a system
      * - `step` - used within a test to denote where within the test steps we are

--- a/packages/aft-core/src/logging/log-level.ts
+++ b/packages/aft-core/src/logging/log-level.ts
@@ -5,7 +5,7 @@ export type LogLevel = typeof levels[number];
  * allows for filtering out of erroneous information from logs by assigning
  * values to different types of logging. the purpose of each log level is
  * as follows:
- * - `trace` - used when logging low-level debug events that occur within a loop
+ * - `trace` - used by AFT internal systems or debug events that would be very chatty (for ex: occur within a loop)
  * - `debug` - used for debug logging that does not run within a loop or at a high frequency
  * - `info` - used for informational events providing current state of a system
  * - `step` - used within a test to denote where within the test steps we are

--- a/packages/aft-core/src/plugins/plugin-loader.ts
+++ b/packages/aft-core/src/plugins/plugin-loader.ts
@@ -147,7 +147,7 @@ class PluginLoader {
                 const keys: string[] = Object.keys(plugin);
                 const name = convert.toSafeString(pluginName, [{exclude: /[-_.\s\d]/gi, replaceWith: ''}]);
                 for (const key of keys) {
-                    if (name.toLowerCase() == key.toLowerCase()) {
+                    if (name.toLowerCase() === key.toLowerCase()) {
                         constructorName = key;
                         break;
                     }

--- a/packages/aft-core/src/plugins/reporting/reporting-manager.ts
+++ b/packages/aft-core/src/plugins/reporting/reporting-manager.ts
@@ -68,6 +68,10 @@ export class ReportingManager {
 
     /**
      * calls the `log` function with a `LogLevel` of `trace`
+     * 
+     * **NOTE**
+     * > this is typically reserved for AFT internal systems and will
+     * result in much more verbose logs if enabled
      * @param message the message to be logged
      */
     async trace(message: string, ...data: Array<any>): Promise<void> {

--- a/packages/aft-core/src/verification/aft-test.ts
+++ b/packages/aft-core/src/verification/aft-test.ts
@@ -311,7 +311,7 @@ export class AftTest {
         try {
             await this._started();
             const shouldRun = await this.shouldRun();
-            await this.reporter.debug(`${this.constructor.name}.shouldRun response:`, shouldRun);
+            await this.reporter.trace(`${this.constructor.name}.shouldRun response:`, shouldRun);
             if (shouldRun.result === true) {
                 await this._testFunction(this);
                 if (this.status === 'failed') {
@@ -364,14 +364,14 @@ export class AftTest {
     }
 
     protected async _started(): Promise<void> {
-        await this.reporter.debug('test starting...');
+        await this.reporter.trace('test starting...');
         this._startTime = new Date().getTime();
         const startedActions: Array<AftTestFunction> = this._options.onEventsMap.get('started');
         await this._runEventActions(startedActions);
     }
 
     protected async _done(): Promise<void> {
-        await this.reporter.debug('test complete');
+        await this.reporter.trace('test complete');
         this._endTime = new Date().getTime();
         const doneActions: Array<AftTestFunction> = this._options.onEventsMap.get('done');
         await this._runEventActions(doneActions);

--- a/packages/aft-core/test/helpers/expiring-file-lock-spec.ts
+++ b/packages/aft-core/test/helpers/expiring-file-lock-spec.ts
@@ -1,0 +1,72 @@
+import { AftConfig, ExpiringFileLock, convert, rand, wait } from "../../src"
+
+describe('ExpiringFileLock', () => {
+    it('can lock a file', () => {
+        const file = rand.getString(15, true);
+        let now: number;
+        let efl: ExpiringFileLock;
+        let blocked: ExpiringFileLock;
+        try {
+            now = Date.now();
+            efl = new ExpiringFileLock(file, new AftConfig({
+                fileLockMaxHold: 5000,
+                fileLockMaxWait: 1000
+            }));
+
+            expect(efl.lockDuration).toEqual(5000);
+            expect(efl.lockName).toContain(file);
+            expect(convert.toElapsedMs(now)).toBeLessThan(1000);
+
+            try {
+                blocked = new ExpiringFileLock(file, new AftConfig({
+                    fileLockMaxHold: 5000,
+                    fileLockMaxWait: 10
+                }));
+
+                expect(false).toBeTrue(); // force failure if here
+            } catch (e) {
+                expect(e.message).toContain('unable to acquire lock on');
+                expect(e.message).toContain(file);
+                expect(e.message).toContain(`within '${10}ms'`);
+            } finally {
+                blocked?.unlock();
+            }
+        } finally {
+            efl?.unlock();
+        }
+    })
+
+    it('automatically expires the lock after a set amount of time', async () => {
+        const file = rand.getString(15, true);
+        let now: number;
+        let efl: ExpiringFileLock;
+        let acquiredAfterWait: ExpiringFileLock;
+        try {
+            now = Date.now();
+            efl = new ExpiringFileLock(file, new AftConfig({
+                fileLockMaxHold: 50,
+                fileLockMaxWait: 1000
+            }));
+
+            expect(efl.lockDuration).toEqual(50);
+            expect(efl.lockName).toContain(file);
+            expect(convert.toElapsedMs(now)).toBeLessThan(1000);
+
+            await wait.forDuration(500);
+
+            try {
+                acquiredAfterWait = new ExpiringFileLock(file, new AftConfig({
+                    fileLockMaxHold: 5000,
+                    fileLockMaxWait: 1000
+                }));
+
+                expect(acquiredAfterWait.lockDuration).toEqual(5000);
+                expect(convert.toElapsedMs(now)).toBeLessThan(1000);
+            } finally {
+                acquiredAfterWait?.unlock();
+            }
+        } finally {
+            efl?.unlock();
+        }
+    })
+})

--- a/packages/aft-jasmine-reporter/package.json
+++ b/packages/aft-jasmine-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-jasmine-reporter",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) Reporter for use with Jasmine Test Framework",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0",
+    "aft-core": "^11.1.0",
     "jasmine": "^5.1.0"
   },
   "devDependencies": {
@@ -39,8 +39,8 @@
     "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
-    "aft-reporting-filesystem": "^11.0.0",
-    "aft-reporting-html": "^11.0.0",
+    "aft-reporting-filesystem": "^11.1.0",
+    "aft-reporting-html": "^11.1.0",
     "eslint": "^8.57.0",
     "nyc": "^15.1.0",
     "rimraf": "^5.0.1",

--- a/packages/aft-jest-reporter/package.json
+++ b/packages/aft-jest-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-jest-reporter",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) Reporter for use with Jest Test Framework",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0",
+    "aft-core": "^11.1.0",
     "jest": "^29.7.0"
   },
   "devDependencies": {
@@ -40,8 +40,8 @@
     "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
-    "aft-reporting-filesystem": "^11.0.0",
-    "aft-reporting-html": "^11.0.0",
+    "aft-reporting-filesystem": "^11.1.0",
+    "aft-reporting-html": "^11.1.0",
     "eslint": "^8.57.0",
     "nyc": "^15.1.0",
     "rimraf": "^5.0.1",

--- a/packages/aft-jira/package.json
+++ b/packages/aft-jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-jira",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) package supporting Jira integration for test execution control and logging",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-web-services": "^11.0.0"
+    "aft-web-services": "^11.1.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.6.4",

--- a/packages/aft-jira/src/policy/jira-policy-plugin.ts
+++ b/packages/aft-jira/src/policy/jira-policy-plugin.ts
@@ -36,7 +36,7 @@ export class JiraPolicyPlugin extends PolicyPlugin {
         if (this.enabled) {
             const openIssues: Array<JiraIssue> = await this._getIssuesReferencingTestIds(testId);
             this.aftLogger.log({
-                level: 'debug',
+                level: 'trace',
                 message: `found ${openIssues.length} open Jira issues for ${testId}: [${openIssues.map(i => i?.key).join(',')}]`,
                 name: this.constructor.name
             });

--- a/packages/aft-jira/src/reporting/jira-reporting-plugin.ts
+++ b/packages/aft-jira/src/reporting/jira-reporting-plugin.ts
@@ -86,7 +86,7 @@ export class JiraReportingPlugin extends ReportingPlugin {
         if (openIssues?.length) {
             this.aftLogger.log({
                 name: this.constructor.name,
-                level: 'debug',
+                level: 'trace',
                 message: `adding comment to Jira issues: [${openIssues.map(i => i?.key).join(',')}] because test '${result.testId}' is still failing...`
             });
             // update comments to indicate the issue still exists
@@ -96,7 +96,7 @@ export class JiraReportingPlugin extends ReportingPlugin {
         } else {
             this.aftLogger.log({
                 name: this.constructor.name,
-                level: 'debug',
+                level: 'trace',
                 message: `creating new Jira issue because test '${result.testId}' failed...`
             });
             // create a new defect
@@ -108,7 +108,7 @@ export class JiraReportingPlugin extends ReportingPlugin {
         const openIssues = await CommonActions.getOpenIssuesReferencingTestId(result.testId, this._api);
         this.aftLogger.log({
             name: this.constructor.name,
-            level: 'debug',
+            level: 'trace',
             message: `closing the following Jira issues due to passing test '${result.testId}': [${openIssues.map(i => i?.key).join(',')}]...`
         });
         for (const issue of openIssues) {

--- a/packages/aft-mocha-reporter/package.json
+++ b/packages/aft-mocha-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-mocha-reporter",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) Reporter for use with Mocha Test Framework",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0",
+    "aft-core": "^11.1.0",
     "mocha": "^10.3.0"
   },
   "devDependencies": {
@@ -40,8 +40,8 @@
     "@types/sinon": "^10.0.20",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
-    "aft-reporting-filesystem": "^11.0.0",
-    "aft-reporting-html": "^11.0.0",
+    "aft-reporting-filesystem": "^11.1.0",
+    "aft-reporting-html": "^11.1.0",
     "chai": "^4.4.1",
     "eslint": "^8.57.0",
     "nyc": "^15.1.0",

--- a/packages/aft-reporting-aws-kinesis-firehose/package.json
+++ b/packages/aft-reporting-aws-kinesis-firehose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-reporting-aws-kinesis-firehose",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) reporting plugin package supporting test reporting to AWS Kinesis Firehose",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0",
+    "aft-core": "^11.1.0",
     "aws-sdk": "^2.1584.0"
   },
   "devDependencies": {

--- a/packages/aft-reporting-filesystem/package.json
+++ b/packages/aft-reporting-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-reporting-filesystem",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) reporting plugin package supporting logging to files",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0",
+    "aft-core": "^11.1.0",
     "date-and-time": "^3.1.1"
   },
   "devDependencies": {

--- a/packages/aft-reporting-html/package.json
+++ b/packages/aft-reporting-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-reporting-html",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) package that creates a HTML results file as a Reporting Plugin",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -44,6 +44,6 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "aft-core": "^11.0.0"
+    "aft-core": "^11.1.0"
   }
 }

--- a/packages/aft-testrail/package.json
+++ b/packages/aft-testrail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-testrail",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) package supporting TestRail integration for test execution control and logging",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-web-services": "^11.0.0"
+    "aft-web-services": "^11.1.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.6.4",

--- a/packages/aft-ui-selenium/package.json
+++ b/packages/aft-ui-selenium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-ui-selenium",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) package supporting UI testing in browsers",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-ui": "^11.0.0",
+    "aft-ui": "^11.1.0",
     "selenium-webdriver": "^4.18.1"
   },
   "devDependencies": {

--- a/packages/aft-ui-selenium/src/sessions/grid-session-generator-plugin.ts
+++ b/packages/aft-ui-selenium/src/sessions/grid-session-generator-plugin.ts
@@ -28,11 +28,11 @@ export class GridSessionGeneratorPlugin extends UiSessionGeneratorPlugin {
                     .build();
                 const handledTime = await Err.handleAsync(() => driver.manage().setTimeouts({implicit: gso.implicitTimeoutMs ?? 1000}));
                 if (handledTime.message) {
-                    await this.reporter.debug(handledTime.message);
+                    await this.reporter.trace(handledTime.message);
                 }
                 const handledMax = await Err.handleAsync(() => driver.manage().window().maximize());
                 if (handledMax.message) {
-                    await this.reporter.debug(handledMax.message);
+                    await this.reporter.trace(handledMax.message);
                 }
             } catch (e) {
                 await this.reporter.warn(`error in creating WebDriver due to: ${Err.full(e)}`);

--- a/packages/aft-ui-selenium/src/sessions/selenium-session.ts
+++ b/packages/aft-ui-selenium/src/sessions/selenium-session.ts
@@ -7,11 +7,11 @@ export class SeleniumSession extends UiSession {
         await super.dispose(error);
         const handledClose = await Err.handleAsync(() => this.driver<WebDriver>().then(d => d?.close()));
         if (handledClose.message) {
-            await this.reporter.debug(handledClose.message);
+            await this.reporter.trace(handledClose.message);
         }
         const handledQuit = await Err.handleAsync(() => this.driver<WebDriver>().then(d => d?.quit()));
         if (handledQuit.message) {
-            await this.reporter.debug(handledQuit.message);
+            await this.reporter.trace(handledQuit.message);
         }
     }
 }

--- a/packages/aft-ui-webdriverio/package.json
+++ b/packages/aft-ui-webdriverio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-ui-webdriverio",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) package supporting UI testing in mobile apps with support for BrowserStack, Sauce Labs and Local Appium",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-ui": "^11.0.0",
+    "aft-ui": "^11.1.0",
     "webdriverio": "^8.35.1"
   },
   "devDependencies": {

--- a/packages/aft-ui-webdriverio/src/sessions/webdriverio-session.ts
+++ b/packages/aft-ui-webdriverio/src/sessions/webdriverio-session.ts
@@ -6,7 +6,7 @@ export class WebdriverIoSession extends UiSession {
         await super.dispose(error);
         const handled = await Err.handleAsync(() => this.driver<WebdriverIO.Browser>().then(d => d.deleteSession())); // eslint-disable-line no-undef
         if (handled.message) {
-            await this.reporter.debug(handled.message);
+            await this.reporter.trace(handled.message);
         }
     }
 }

--- a/packages/aft-ui/package.json
+++ b/packages/aft-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-ui",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) core package supporting UI testing via plugins",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0"
+    "aft-core": "^11.1.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.6.4",

--- a/packages/aft-ui/src/sessions/ui-session-generator-manager.ts
+++ b/packages/aft-ui/src/sessions/ui-session-generator-manager.ts
@@ -52,7 +52,7 @@ export class UiSessionGeneratorManager {
             const plugin = this.plugins.find(p => p); // get ONLY first result
             aftLogger.log({
                 name: this.constructor.name,
-                level: 'debug',
+                level: 'trace',
                 message: `using plugin: '${plugin.constructor.name}' to generate new UI session using options: ${JSON.stringify(sessionOptions)}`
             });
             return await plugin.getSession(sessionOptions);

--- a/packages/aft-vitest-reporter/.eslintrc
+++ b/packages/aft-vitest-reporter/.eslintrc
@@ -1,0 +1,13 @@
+{
+  "extends": "eslint:recommended",
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": { "project": "./tsconfig.json" },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "no-inner-declarations": ["off"],
+    "no-prototype-builtins": ["off"],
+    "no-case-declarations": ["off"],
+    "@typescript-eslint/no-floating-promises": ["error"]
+  },
+  "ignorePatterns": ["/*", "!/src"]
+}

--- a/packages/aft-vitest-reporter/README.md
+++ b/packages/aft-vitest-reporter/README.md
@@ -1,0 +1,60 @@
+# AFT-Vitest-Reporter
+a Vitest `Reporter` integration for AFT providing support for AFT plugins, configuration and helpers
+
+## Installation
+`> npm i aft-vitest-reporter`
+
+## Vitest Configuration
+using this `Reporter` requires either calling the `vitest` command with the following argument `--reporter=aft-vitest-reporter` or from within a `vitest.config.mjs` file like the following: 
+```javascript
+// vitest.config.mjs
+import { defineConfig, configDefaults } from 'vitest/config';
+
+export default defineConfig({
+  ...configDefaults,
+  test: {
+    reporters: ['default', './node_modules/aft-vitest-reporter/dist/src/aft-vitest-reporter.js'],
+    environment: 'node',
+  }
+});
+```
+
+## AFT Helpers
+this package comes with two helper classes that can be utilised from within your Vitest specs to make use of AFT features.
+
+### `AftVitestTest`
+the `AftVitestTest` class extends from the `AftTest` class providing the ability to parse the Spec name for any referenced Test. each Test ID must be surrounded with square brackets `[ABC123]`. you can then either directly call the `AftVitestTest.shouldRun()` async function which will determine if your test should be run based on any AFT `PolicyPlugin` instances referenced in your `aftconfig.json` file or you can call `aftVitestTest(this, testFunction)` which will perform the `AftVitestTest.shouldRun()` call and mark the test as skipped if it should not be run. using the `AftVitestTest` class would look like the following:
+> **!!WARNING!!** using arrow functions in your Spec definition **IS NOT SUPPORTED** if using `AftVitestTest` because it removes the `this` scope
+```javascript
+describe('YourTestSuite', () => {
+    // use `aftVitestTest` to report results
+    it('can check if test [C1234] should be run', async function() {
+        await aftVitestTest(this, async (v: AftVitestTest) => {
+            // calls `v.test.skip()` if should not be run
+            await v.reporter.error('we should never get here if C1234 should not be run');
+            const result = await doStuff();
+            await t.verify(result, equaling('expected'));
+        }); // handles submitting the result to any AFT Reporter Plugins
+    });
+
+    // use `AftVitestReporter` to report results
+    it('can check if test [C2345] should be run', async function() {
+        const aft = new AftVitestTest(this);
+        const shouldRun = await aft.shouldRun();
+        if (shouldRun.result !== true) {
+            await aft.pending(shouldRun.message); // marks test as skipped
+        }
+        const result = await doStuff();
+        expect(result).to.equal('expected'); // AftVitestReporter handles submitting the result to any AFT Reporter Plugins
+    });
+});
+```
+which would output the following to your console and any AFT `ReportingPlugin` instances referenced in your `aftconfig.json` if the test ID should not be run:
+```text
+17:52:45 - [YourTestSuite can check if test [C1234] should be run] - WARN - none of the supplied tests should be run: [C1234]
+17:52:45 - [YourTestSuite can check if test [C1234] should be run] - WARN - test skipped
+```
+
+## NOTES
+- the `AftVitestTest` constructors expects to be passed a valid `scope` containing reference to the currently executing `Vitest.Test`. typically this will be an object passed in to your `test` or `it` function within your Spec
+- this Vitest `Reporter` works in both parallel and sequential execution modes, but you **MUST ALWAYS** pass a context to your `it` or `test` function if you are using `AftVitestTest` class within your Spec

--- a/packages/aft-vitest-reporter/README.md
+++ b/packages/aft-vitest-reporter/README.md
@@ -58,3 +58,4 @@ which would output the following to your console and any AFT `ReportingPlugin` i
 ## NOTES
 - the `AftVitestTest` constructors expects to be passed a valid `scope` containing reference to the currently executing `Vitest.Test`. typically this will be an object passed in to your `test` or `it` function within your Spec
 - this Vitest `Reporter` works in both parallel and sequential execution modes, but you **MUST ALWAYS** pass a context to your `it` or `test` function if you are using `AftVitestTest` class within your Spec
+- the `aft-vitest-reporter` Vitest Reporter can be used when testing with an environment of `node` or `jsdom` or any of the supported Vitest environment config values, but the `AftVitestTest` class and `aftVitestTest` function can only be used with your environment set to `node` via your `vitest.config.mjs` file

--- a/packages/aft-vitest-reporter/aftconfig.json
+++ b/packages/aft-vitest-reporter/aftconfig.json
@@ -1,0 +1,7 @@
+{
+    "plugins": [
+        {"name": "html-reporting-plugin", "searchDir": "../"},
+        {"name": "filesystem-reporting-plugin", "searchDir": "../"}
+    ],
+    "logLevel": "debug"
+}

--- a/packages/aft-vitest-reporter/package.json
+++ b/packages/aft-vitest-reporter/package.json
@@ -9,7 +9,7 @@
     "build": "npm run lint && npm run clean && tsc --build",
     "lint": "npx eslint --fix ./src --ext .ts",
     "test": "npm run build && npx vitest run",
-    "coverage": "npm run build && nyc npx vitest"
+    "coverage": "npm run build && nyc npx vitest run"
   },
   "repository": {
     "type": "git",

--- a/packages/aft-vitest-reporter/package.json
+++ b/packages/aft-vitest-reporter/package.json
@@ -9,7 +9,7 @@
     "build": "npm run lint && npm run clean && tsc --build",
     "lint": "npx eslint --fix ./src --ext .ts",
     "test": "npm run build && npx vitest run",
-    "coverage": "npm run build && nyc npx vitest run"
+    "coverage": "npm run build && npx vitest run --coverage"
   },
   "repository": {
     "type": "git",
@@ -35,6 +35,7 @@
     "vitest": "^1.5.0"
   },
   "devDependencies": {
+    "@vitest/coverage-istanbul": "^1.5.0",
     "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",

--- a/packages/aft-vitest-reporter/package.json
+++ b/packages/aft-vitest-reporter/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "aft-vitest-reporter",
+  "version": "11.0.0",
+  "description": "Automated Functional Testing (AFT) Reporter for use with Vite Test Framework (vitest)",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "clean": "rimraf ./dist && rimraf ./logs && rimraf ./FileSystemMap && rimraf ./testresults.html",
+    "build": "npm run lint && npm run clean && tsc --build",
+    "lint": "npx eslint --fix ./src --ext .ts",
+    "test": "npm run build && npx vitest run",
+    "coverage": "npm run build && nyc npx vitest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bicarbon8/automated-functional-testing.git"
+  },
+  "keywords": [
+    "aft",
+    "functional",
+    "automation",
+    "e2e",
+    "integration",
+    "vitest",
+    "reporter"
+  ],
+  "author": "Jason Holt Smith <bicarbon8@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bicarbon8/automated-functional-testing/issues"
+  },
+  "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
+  "dependencies": {
+    "aft-core": "^11.0.0",
+    "vitest": "^1.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^7.4.0",
+    "@typescript-eslint/parser": "^7.4.0",
+    "aft-reporting-filesystem": "^11.0.0",
+    "aft-reporting-html": "^11.0.0",
+    "eslint": "^8.57.0",
+    "nyc": "^15.1.0",
+    "rimraf": "^5.0.1",
+    "typescript": "^5.1.6"
+  }
+}

--- a/packages/aft-vitest-reporter/package.json
+++ b/packages/aft-vitest-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-vitest-reporter",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) Reporter for use with Vite Test Framework (vitest)",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -31,15 +31,15 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0",
+    "aft-core": "^11.1.0",
     "vitest": "^1.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
-    "aft-reporting-filesystem": "^11.0.0",
-    "aft-reporting-html": "^11.0.0",
+    "aft-reporting-filesystem": "^11.1.0",
+    "aft-reporting-html": "^11.1.0",
     "eslint": "^8.57.0",
     "nyc": "^15.1.0",
     "rimraf": "^5.0.1",

--- a/packages/aft-vitest-reporter/src/aft-vitest-reporter.ts
+++ b/packages/aft-vitest-reporter/src/aft-vitest-reporter.ts
@@ -1,0 +1,73 @@
+import * as vt from 'vitest';
+import { AftVitestTest } from './aft-vitest-test';
+import { AftConfig, Err, FileSystemMap, aftConfig } from 'aft-core';
+
+/**
+ * this reporter integrates the Automated Functional Testing (AFT)
+ * library into Mocha
+ */
+export default class AftVitestReporter implements vt.Reporter {
+    private _aftCfg: AftConfig;
+
+    withAftCfg(aftCfg?: AftConfig): this {
+        this._aftCfg = aftCfg;
+        return this;
+    }
+
+    get aftCfg(): AftConfig {
+        if (!this._aftCfg) {
+            this._aftCfg = aftConfig;
+        }
+        return this._aftCfg;
+    }
+
+    onInit(ctx: vt.Vitest): void { // eslint-disable-line no-unused-vars
+        FileSystemMap.removeCacheFile(AftVitestTest.name, this.aftCfg);
+    }
+
+    async onFinished(filesOrTasks: Array<vt.File | vt.Task>): Promise<void> {
+        for (const file of filesOrTasks) {
+            if (file.type === 'suite') {
+                const tasks = file.tasks;
+                await this.onFinished(tasks);
+            } else if (file.type === 'test') {
+                await this._processTaskResults(...filesOrTasks);
+            }
+        }
+    }
+
+    private async _processTaskResults(...tasks: Array<vt.Task>): Promise<void> {
+        for (const task of tasks) {
+            try {
+                const t = new AftVitestTest({task}, null, {aftCfg: this.aftCfg});
+                // if we don't already have results for this test
+                if (t.results?.length === 0 && task.result.state !== 'run') {
+                    // then send task
+                    switch (task.result.state) {
+                        case 'fail':
+                            const errStrings = new Array<string>();
+                            for (const err of task.result.errors) {
+                                const errString = Err.handle(() => err.message);
+                                if (!errString.message) {
+                                    errStrings.push(errString.result);
+                                }
+                            }
+                            await t.fail(errStrings.join(','));
+                            break;
+                        case 'pass':
+                            await t.pass();
+                            break;
+                        case 'skip':
+                            await t.pending();
+                            break;
+                        default:
+                            await t.reporter.warn(`unknown state '${task.result.state}' received`);
+                            break;
+                    }
+                }
+            } catch (e) {
+                console.log(Err.full(e)); // eslint-disable-line no-undef
+            }
+        }
+    }
+}

--- a/packages/aft-vitest-reporter/src/aft-vitest-test.ts
+++ b/packages/aft-vitest-reporter/src/aft-vitest-test.ts
@@ -1,0 +1,80 @@
+import { TaskContext, Test } from "vitest";
+import { AftTest, AftTestFunction, AftTestOptions, Func, rand } from "aft-core";
+
+/**
+ * expects to be passed the context from an executing Vitest
+ * task (i.e. the `ctx` argument)
+ * > **NOTE:**
+ * > 
+ * > the Vitest `ctx` context is only available when tests
+ * are written using
+ * > 
+ * > `it('description', function(ctx) {...})`
+ * >
+ * > or `it('description', (ctx) => {...})`
+ * >
+ * > and _not_ when using
+ * >
+ * > `it('description', () => {...})`
+ * >
+ * > or `it('description', function() => {...})`
+ * >
+ * @param context the `ctx` context object passed to a Vitest `it`
+ */
+export class AftVitestTest extends AftTest {
+    /**
+     * an instance of a `Vitest.Context` from the `ctx` context
+     * passed to a Vitest `it` function as an argument
+     * `ctx`
+     * > NOTE: if no `ctx` argument is passed to your `it`
+     * function this will not be available
+     */
+    public readonly test: Test;
+
+    constructor(context?: any, testFunction?: AftTestFunction, options?: AftTestOptions) {
+        testFunction ??= () => null;
+        options ??= {};
+        options.cacheResultsToFile = true;
+        let description: string;
+        if (context?.task?.type === 'test') {
+            description = `${context.task.suite?.name} ${context.task.name}`;
+        } else if (typeof context === 'string') {
+            description = context;
+        } else {
+            description = `${AftVitestTest.name}_${rand.getString(8, true, true)}`;
+        }
+        super(description, testFunction, options);
+        this.test = (context?.task) ? context.task : null;
+    }
+
+    override async pending(message?: string, ...testIds: Array<string>): Promise<void> {
+        await super.pending(message, ...testIds);
+        this.test?.context?.skip?.();
+    }
+}
+
+/**
+ * creates a new `AftVitestTest` instace to be used for executing some Functional
+ * Test Assertion and calls the `run` function to execute the `testFunction`.
+ * 
+ * ex:
+ * ```typescript
+ * it('[C1234] example usage for AftTest', async (ctx) => {
+ *     await AftVitestTest(ctx, async (v: AftVitestTest) => {
+ *        await v.reporter.info('doing some testing...');
+ *        const feature = new FeatureObj();
+ *        await v.verify(() => feature.returnExpectedValueAsync(), equaling('expected value'));
+ *     }); // if PolicyManager.shouldRun('C1234') returns `false` the assertion is not run
+ * })
+ * ```
+ * @param context a `ctx` representing the current `Vitest` instance containing the
+ * `Vitest.Task` used to get the test description or a `string` description
+ * @param testFunction the `Func<AftVitestTest, void | PromiseLike<void>>` function to be
+ * executed by this `AftVitestTest`
+ * @param options an optional `AftTestOptions` object containing overrides to internal
+ * configuration and settings
+ * @returns an async `Promise<void>` that runs the passed in `testFunction`
+ */
+export const aftVitestTest = async (context: TaskContext | string, testFunction: Func<AftVitestTest, void | PromiseLike<void>>, options?: AftTestOptions): Promise<void> => {
+    return new AftVitestTest(context, testFunction, options).run();
+};

--- a/packages/aft-vitest-reporter/src/index.ts
+++ b/packages/aft-vitest-reporter/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./aft-vitest-reporter";
+export * from "./aft-vitest-test";

--- a/packages/aft-vitest-reporter/test/aft-vitest-reporter.spec.ts
+++ b/packages/aft-vitest-reporter/test/aft-vitest-reporter.spec.ts
@@ -1,0 +1,48 @@
+import { it, describe, expect, vi, TaskContext } from "vitest";
+import { AftVitestTest, aftVitestTest } from "../src";
+import { containing } from "aft-core";
+
+describe('AftVitestReporter', () => {
+    it('passes a Vitest context to the test that can be used by AftVitestTest', async function(ctx: TaskContext) {
+        const t = new AftVitestTest(ctx);
+        const shouldRun = await t.shouldRun();
+        if (!shouldRun.result) { 
+            await t.pending(shouldRun.message);
+        }
+        expect(t).to.exist;
+        expect(t.reporter).to.exist;
+        expect(t.reporter.name).to.equal(t.description);
+
+        await t.reporter.trace('sample log message');
+    });
+
+    it('can skip a test during execution', async (ctx: TaskContext) => {
+        const t = new AftVitestTest(ctx);
+        vi.spyOn(t, 'shouldRun').mockImplementation(() => Promise.resolve({result: false, message: 'fake'}));
+        const shouldRun = await t.shouldRun();
+        if (!shouldRun.result) { 
+            await t.pending(shouldRun.message);
+        }
+        
+        expect(true).to.be.false; // force failure if we get here
+    });
+
+    it('still works if using an arrow function', async (ctx: TaskContext) => {
+        const t = new AftVitestTest(ctx);
+        
+        expect(t).to.exist;
+        expect(t.reporter).to.exist;
+        expect(t.description).to.contain('arrow function');
+        expect(t.test).to.equal(ctx.task);
+        expect(t.reporter.name).to.equal(t.description);
+
+        await t.reporter.trace('sample log message from aft-vitest-reporter.spec with arrow function');
+    });
+
+    it('[C1234] provides a AftVitestTest instance for use in test control', async (ctx: TaskContext) => {
+        await aftVitestTest(ctx, async (v: AftVitestTest) => {
+            await v.verify(v.description, 'AftVitestReporter [C1234] provides a AftVitestTest instance for use in test control');
+            await v.verify(v.testIds, containing('C1234'), 'expected to parse test ID from description');
+        });
+    });
+});

--- a/packages/aft-vitest-reporter/tsconfig.json
+++ b/packages/aft-vitest-reporter/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../../tsconfig.settings.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "composite": true,
+        "types": ["vitest"]
+    },
+    "include": ["src", "test"],
+    "references": [
+        { "path": "../aft-core" },
+        { "path": "../aft-reporting-html" },
+        { "path": "../aft-reporting-filesystem" }
+    ]
+}

--- a/packages/aft-vitest-reporter/vitest.config.mjs
+++ b/packages/aft-vitest-reporter/vitest.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig, configDefaults } from 'vitest/config';
+
+export default defineConfig({
+  ...configDefaults,
+  test: {
+    testTimeout: 10000,
+    reporters: ['default', './dist/src/aft-vitest-reporter.js'],
+    environment: 'node',
+  }
+});

--- a/packages/aft-vitest-reporter/vitest.config.mjs
+++ b/packages/aft-vitest-reporter/vitest.config.mjs
@@ -6,5 +6,8 @@ export default defineConfig({
     testTimeout: 10000,
     reporters: ['default', './dist/src/aft-vitest-reporter.js'],
     environment: 'node',
+    coverage: {
+        provider: 'istanbul'
+    },
   }
 });

--- a/packages/aft-web-services/package.json
+++ b/packages/aft-web-services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-web-services",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Automated Functional Testing (AFT) module for testing web services over HTTP and HTTPS",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^11.0.0",
+    "aft-core": "^11.1.0",
     "form-data": "^4.0.0",
     "xmldoc": "^1.3.0"
   },

--- a/packages/aft-web-services/src/http/http-service.ts
+++ b/packages/aft-web-services/src/http/http-service.ts
@@ -98,7 +98,7 @@ export class HttpService {
             } else {
                 aftLogger.log({
                     name: this.constructor.name,
-                    level: 'debug',
+                    level: 'trace',
                     message: logMessage
                 });
             }
@@ -112,7 +112,7 @@ export class HttpService {
             } else {
                 aftLogger.log({
                     name: this.constructor.name,
-                    level: 'debug',
+                    level: 'trace',
                     message: logMessage
                 });
             }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         { "path": "./packages/aft-ui" },
         { "path": "./packages/aft-ui-selenium" },
         { "path": "./packages/aft-ui-webdriverio" },
+        { "path": "./packages/aft-vitest-reporter" },
         { "path": "./packages/aft-web-services" }
     ],
     "files": []


### PR DESCRIPTION
* splits functional test action to it's own workflow that is manually triggered to avoid automatic failures on externally submitted PRs
* adds support for Vitest with aft-vitest-reporter package
* removes reference to fs-ext package and implements more compatible but less accurate form of exclusive cross process locking
* fixes #80
* fixes #81
* fixes #82