### PR TITLE
Fix file reporter length

### DIFF
--- a/examples/cypress-mocha/package.json
+++ b/examples/cypress-mocha/package.json
@@ -29,13 +29,13 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
-    "aft-jira": "^12.0.0",
-    "aft-mocha-reporter": "^12.0.0",
-    "aft-reporting-aws-kinesis-firehose": "^12.0.0",
-    "aft-reporting-filesystem": "^12.0.0",
-    "aft-reporting-html": "^12.0.0",
-    "aft-testrail": "^12.0.0"
+    "aft-core": "^12.0.1",
+    "aft-jira": "^12.0.1",
+    "aft-mocha-reporter": "^12.0.1",
+    "aft-reporting-aws-kinesis-firehose": "^12.0.1",
+    "aft-reporting-filesystem": "^12.0.1",
+    "aft-reporting-html": "^12.0.1",
+    "aft-testrail": "^12.0.1"
   },
   "devDependencies": {
     "chai": "^4.4.1",
@@ -44,5 +44,5 @@
     "rimraf": "^5.0.1",
     "typescript": "^5.1.6"
   },
-  "version": "12.0.0"
+  "version": "12.0.1"
 }

--- a/examples/selenium-jest/package.json
+++ b/examples/selenium-jest/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
-    "aft-jest-reporter": "^12.0.0",
-    "aft-jira": "^12.0.0",
-    "aft-reporting-aws-kinesis-firehose": "^12.0.0",
-    "aft-reporting-filesystem": "^12.0.0",
-    "aft-reporting-html": "^12.0.0",
-    "aft-testrail": "^12.0.0",
-    "aft-ui-selenium": "^12.0.0"
+    "aft-core": "^12.0.1",
+    "aft-jest-reporter": "^12.0.1",
+    "aft-jira": "^12.0.1",
+    "aft-reporting-aws-kinesis-firehose": "^12.0.1",
+    "aft-reporting-filesystem": "^12.0.1",
+    "aft-reporting-html": "^12.0.1",
+    "aft-testrail": "^12.0.1",
+    "aft-ui-selenium": "^12.0.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
@@ -47,5 +47,5 @@
     "rimraf": "^5.0.1",
     "typescript": "^5.1.6"
   },
-  "version": "12.0.0"
+  "version": "12.0.1"
 }

--- a/examples/selenium-mocha/package.json
+++ b/examples/selenium-mocha/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
-    "aft-jira": "^12.0.0",
-    "aft-mocha-reporter": "^12.0.0",
-    "aft-reporting-aws-kinesis-firehose": "^12.0.0",
-    "aft-reporting-filesystem": "^12.0.0",
-    "aft-reporting-html": "^12.0.0",
-    "aft-testrail": "^12.0.0",
-    "aft-ui-selenium": "^12.0.0"
+    "aft-core": "^12.0.1",
+    "aft-jira": "^12.0.1",
+    "aft-mocha-reporter": "^12.0.1",
+    "aft-reporting-aws-kinesis-firehose": "^12.0.1",
+    "aft-reporting-filesystem": "^12.0.1",
+    "aft-reporting-html": "^12.0.1",
+    "aft-testrail": "^12.0.1",
+    "aft-ui-selenium": "^12.0.1"
   },
   "devDependencies": {
     "@types/chai": "^4.3.14",
@@ -50,5 +50,5 @@
     "ts-mocha": "^10.0.0",
     "typescript": "^5.1.6"
   },
-  "version": "12.0.0"
+  "version": "12.0.1"
 }

--- a/examples/web-services-jasmine/package.json
+++ b/examples/web-services-jasmine/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
-    "aft-jasmine-reporter": "^12.0.0",
-    "aft-jira": "^12.0.0",
-    "aft-reporting-aws-kinesis-firehose": "^12.0.0",
-    "aft-reporting-filesystem": "^12.0.0",
-    "aft-reporting-html": "^12.0.0",
-    "aft-testrail": "^12.0.0",
-    "aft-web-services": "^12.0.0"
+    "aft-core": "^12.0.1",
+    "aft-jasmine-reporter": "^12.0.1",
+    "aft-jira": "^12.0.1",
+    "aft-reporting-aws-kinesis-firehose": "^12.0.1",
+    "aft-reporting-filesystem": "^12.0.1",
+    "aft-reporting-html": "^12.0.1",
+    "aft-testrail": "^12.0.1",
+    "aft-web-services": "^12.0.1"
   },
   "devDependencies": {
     "@types/jasmine": "^5.1.4",
@@ -46,5 +46,5 @@
     "rimraf": "^5.0.1",
     "typescript": "^5.1.6"
   },
-  "version": "12.0.0"
+  "version": "12.0.1"
 }

--- a/examples/webdriverio-mocha/package.json
+++ b/examples/webdriverio-mocha/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
-    "aft-jira": "^12.0.0",
-    "aft-mocha-reporter": "^12.0.0",
-    "aft-reporting-aws-kinesis-firehose": "^12.0.0",
-    "aft-reporting-filesystem": "^12.0.0",
-    "aft-reporting-html": "^12.0.0",
-    "aft-testrail": "^12.0.0",
-    "aft-ui-webdriverio": "^12.0.0",
+    "aft-core": "^12.0.1",
+    "aft-jira": "^12.0.1",
+    "aft-mocha-reporter": "^12.0.1",
+    "aft-reporting-aws-kinesis-firehose": "^12.0.1",
+    "aft-reporting-filesystem": "^12.0.1",
+    "aft-reporting-html": "^12.0.1",
+    "aft-testrail": "^12.0.1",
+    "aft-ui-webdriverio": "^12.0.1",
     "webdriverio": "^8.35.1"
   },
   "devDependencies": {
@@ -51,5 +51,5 @@
     "ts-mocha": "^10.0.0",
     "typescript": "^5.1.6"
   },
-  "version": "12.0.0"
+  "version": "12.0.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "packages/*",
     "examples/*"
   ],
-  "version": "12.0.0"
+  "version": "12.0.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "examples/*"
       ],
       "devDependencies": {
-        "@nx/nx-linux-x64-gnu": "^19.0.3",
         "dpdm": "^3.14.0",
         "lerna": "^7.4.2",
         "typedoc": "^0.24.8"
@@ -2034,21 +2033,6 @@
       ],
       "dev": true,
       "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.0.3.tgz",
-      "integrity": "sha512-DnXWWN7xHXHA5ij8Dc09FS5vBjs4Ea2JvTttR98GT7+yLAgoxt8hDjUPzRNpbTQZUyf+bTSbpgmwTlHyXLquCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
       "os": [
         "linux"
       ],
@@ -5839,8 +5823,9 @@
       }
     },
     "node_modules/date-and-time": {
-      "version": "3.1.1",
-      "license": "MIT"
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-3.2.0.tgz",
+      "integrity": "sha512-uI8c96oG3R8ZhtWeGy8SfJSN1POcwE7kjWLi7GB3+dmBqSYGG+KhGf4Vh25hUhg1Br6Kn3ikEf/mrXCxE0Pknw=="
     },
     "node_modules/dateformat": {
       "version": "3.0.3",
@@ -17384,7 +17369,8 @@
       "license": "MIT",
       "dependencies": {
         "aft-core": "^12.0.0",
-        "aws-sdk": "^2.1584.0"
+        "aws-sdk": "^2.1584.0",
+        "date-and-time": "^3.2.0"
       },
       "devDependencies": {
         "@aws-sdk/types": "^3.535.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,16 +16,16 @@
       }
     },
     "examples/cypress-mocha": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
-        "aft-jira": "^12.0.0",
-        "aft-mocha-reporter": "^12.0.0",
-        "aft-reporting-aws-kinesis-firehose": "^12.0.0",
-        "aft-reporting-filesystem": "^12.0.0",
-        "aft-reporting-html": "^12.0.0",
-        "aft-testrail": "^12.0.0"
+        "aft-core": "^12.0.1",
+        "aft-jira": "^12.0.1",
+        "aft-mocha-reporter": "^12.0.1",
+        "aft-reporting-aws-kinesis-firehose": "^12.0.1",
+        "aft-reporting-filesystem": "^12.0.1",
+        "aft-reporting-html": "^12.0.1",
+        "aft-testrail": "^12.0.1"
       },
       "devDependencies": {
         "chai": "^4.4.1",
@@ -53,17 +53,17 @@
       }
     },
     "examples/selenium-jest": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
-        "aft-jest-reporter": "^12.0.0",
-        "aft-jira": "^12.0.0",
-        "aft-reporting-aws-kinesis-firehose": "^12.0.0",
-        "aft-reporting-filesystem": "^12.0.0",
-        "aft-reporting-html": "^12.0.0",
-        "aft-testrail": "^12.0.0",
-        "aft-ui-selenium": "^12.0.0"
+        "aft-core": "^12.0.1",
+        "aft-jest-reporter": "^12.0.1",
+        "aft-jira": "^12.0.1",
+        "aft-reporting-aws-kinesis-firehose": "^12.0.1",
+        "aft-reporting-filesystem": "^12.0.1",
+        "aft-reporting-html": "^12.0.1",
+        "aft-testrail": "^12.0.1",
+        "aft-ui-selenium": "^12.0.1"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -93,17 +93,17 @@
       }
     },
     "examples/selenium-mocha": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
-        "aft-jira": "^12.0.0",
-        "aft-mocha-reporter": "^12.0.0",
-        "aft-reporting-aws-kinesis-firehose": "^12.0.0",
-        "aft-reporting-filesystem": "^12.0.0",
-        "aft-reporting-html": "^12.0.0",
-        "aft-testrail": "^12.0.0",
-        "aft-ui-selenium": "^12.0.0"
+        "aft-core": "^12.0.1",
+        "aft-jira": "^12.0.1",
+        "aft-mocha-reporter": "^12.0.1",
+        "aft-reporting-aws-kinesis-firehose": "^12.0.1",
+        "aft-reporting-filesystem": "^12.0.1",
+        "aft-reporting-html": "^12.0.1",
+        "aft-testrail": "^12.0.1",
+        "aft-ui-selenium": "^12.0.1"
       },
       "devDependencies": {
         "@types/chai": "^4.3.14",
@@ -136,17 +136,17 @@
       }
     },
     "examples/web-services-jasmine": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
-        "aft-jasmine-reporter": "^12.0.0",
-        "aft-jira": "^12.0.0",
-        "aft-reporting-aws-kinesis-firehose": "^12.0.0",
-        "aft-reporting-filesystem": "^12.0.0",
-        "aft-reporting-html": "^12.0.0",
-        "aft-testrail": "^12.0.0",
-        "aft-web-services": "^12.0.0"
+        "aft-core": "^12.0.1",
+        "aft-jasmine-reporter": "^12.0.1",
+        "aft-jira": "^12.0.1",
+        "aft-reporting-aws-kinesis-firehose": "^12.0.1",
+        "aft-reporting-filesystem": "^12.0.1",
+        "aft-reporting-html": "^12.0.1",
+        "aft-testrail": "^12.0.1",
+        "aft-web-services": "^12.0.1"
       },
       "devDependencies": {
         "@types/jasmine": "^5.1.4",
@@ -180,17 +180,17 @@
       }
     },
     "examples/webdriverio-mocha": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
-        "aft-jira": "^12.0.0",
-        "aft-mocha-reporter": "^12.0.0",
-        "aft-reporting-aws-kinesis-firehose": "^12.0.0",
-        "aft-reporting-filesystem": "^12.0.0",
-        "aft-reporting-html": "^12.0.0",
-        "aft-testrail": "^12.0.0",
-        "aft-ui-webdriverio": "^12.0.0",
+        "aft-core": "^12.0.1",
+        "aft-jira": "^12.0.1",
+        "aft-mocha-reporter": "^12.0.1",
+        "aft-reporting-aws-kinesis-firehose": "^12.0.1",
+        "aft-reporting-filesystem": "^12.0.1",
+        "aft-reporting-html": "^12.0.1",
+        "aft-testrail": "^12.0.1",
+        "aft-ui-webdriverio": "^12.0.1",
         "webdriverio": "^8.35.1"
       },
       "devDependencies": {
@@ -17170,7 +17170,7 @@
       }
     },
     "packages/aft-core": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
         "colors": "^1.4.0",
@@ -17211,10 +17211,10 @@
       }
     },
     "packages/aft-jasmine-reporter": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
+        "aft-core": "^12.0.1",
         "jasmine": "^5.1.0"
       },
       "devDependencies": {
@@ -17222,8 +17222,8 @@
         "@types/node": "^20.11.30",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
-        "aft-reporting-filesystem": "^12.0.0",
-        "aft-reporting-html": "^12.0.0",
+        "aft-reporting-filesystem": "^12.0.1",
+        "aft-reporting-html": "^12.0.1",
         "eslint": "^8.57.0",
         "nyc": "^15.1.0",
         "rimraf": "^5.0.1",
@@ -17249,10 +17249,10 @@
       }
     },
     "packages/aft-jest-reporter": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
+        "aft-core": "^12.0.1",
         "jest": "^29.7.0"
       },
       "devDependencies": {
@@ -17261,8 +17261,8 @@
         "@types/node": "^20.11.30",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
-        "aft-reporting-filesystem": "^12.0.0",
-        "aft-reporting-html": "^12.0.0",
+        "aft-reporting-filesystem": "^12.0.1",
+        "aft-reporting-html": "^12.0.1",
         "eslint": "^8.57.0",
         "nyc": "^15.1.0",
         "rimraf": "^5.0.1",
@@ -17288,10 +17288,10 @@
       }
     },
     "packages/aft-jira": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-web-services": "^12.0.0"
+        "aft-web-services": "^12.0.1"
       },
       "devDependencies": {
         "@types/jasmine": "^4.6.4",
@@ -17324,10 +17324,10 @@
       }
     },
     "packages/aft-mocha-reporter": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
+        "aft-core": "^12.0.1",
         "mocha": "^10.3.0"
       },
       "devDependencies": {
@@ -17336,8 +17336,8 @@
         "@types/sinon": "^10.0.20",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
-        "aft-reporting-filesystem": "^12.0.0",
-        "aft-reporting-html": "^12.0.0",
+        "aft-reporting-filesystem": "^12.0.1",
+        "aft-reporting-html": "^12.0.1",
         "chai": "^4.4.1",
         "eslint": "^8.57.0",
         "nyc": "^15.1.0",
@@ -17365,10 +17365,10 @@
       }
     },
     "packages/aft-reporting-aws-kinesis-firehose": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
+        "aft-core": "^12.0.1",
         "aws-sdk": "^2.1584.0",
         "date-and-time": "^3.2.0"
       },
@@ -17404,10 +17404,10 @@
       }
     },
     "packages/aft-reporting-filesystem": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
+        "aft-core": "^12.0.1",
         "date-and-time": "^3.1.1"
       },
       "devDependencies": {
@@ -17441,10 +17441,10 @@
       }
     },
     "packages/aft-reporting-html": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0"
+        "aft-core": "^12.0.1"
       },
       "devDependencies": {
         "@types/jasmine": "^4.6.4",
@@ -17477,10 +17477,10 @@
       }
     },
     "packages/aft-testrail": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-web-services": "^12.0.0"
+        "aft-web-services": "^12.0.1"
       },
       "devDependencies": {
         "@types/jasmine": "^4.6.4",
@@ -17513,10 +17513,10 @@
       }
     },
     "packages/aft-ui": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0"
+        "aft-core": "^12.0.1"
       },
       "devDependencies": {
         "@types/jasmine": "^4.6.4",
@@ -17532,10 +17532,10 @@
       }
     },
     "packages/aft-ui-selenium": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-ui": "^12.0.0",
+        "aft-ui": "^12.0.1",
         "selenium-webdriver": "^4.18.1"
       },
       "devDependencies": {
@@ -17571,10 +17571,10 @@
       }
     },
     "packages/aft-ui-webdriverio": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-ui": "^12.0.0",
+        "aft-ui": "^12.0.1",
         "webdriverio": "^8.35.1"
       },
       "devDependencies": {
@@ -17625,10 +17625,10 @@
       }
     },
     "packages/aft-vitest-reporter": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
+        "aft-core": "^12.0.1",
         "vitest": "^1.5.0"
       },
       "devDependencies": {
@@ -17636,8 +17636,8 @@
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
         "@vitest/coverage-istanbul": "^1.5.0",
-        "aft-reporting-filesystem": "^12.0.0",
-        "aft-reporting-html": "^12.0.0",
+        "aft-reporting-filesystem": "^12.0.1",
+        "aft-reporting-html": "^12.0.1",
         "eslint": "^8.57.0",
         "nyc": "^15.1.0",
         "rimraf": "^5.0.1",
@@ -17663,10 +17663,10 @@
       }
     },
     "packages/aft-web-services": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
-        "aft-core": "^12.0.0",
+        "aft-core": "^12.0.1",
         "form-data": "^4.0.0",
         "xmldoc": "^1.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "coverage": "npm run coverage --workspaces --if-present",
     "test:core": "npm run test --workspace=aft-core",
     "test:jira": "npm run test --workspace=aft-jira",
-    "test:kinesis": "npm run test --workspace=aft-reporting-aws-kinesis-firehose",
+    "test:firehose": "npm run test --workspace=aft-reporting-aws-kinesis-firehose",
     "test:testrail": "npm run test --workspace=aft-testrail",
     "test:ui": "npm run test --workspace=aft-ui",
     "test:selenium": "npm run test --workspace=aft-ui-selenium",
@@ -30,7 +30,6 @@
     "circular": "npx dpdm -T --warning false **/index.ts"
   },
   "devDependencies": {
-    "@nx/nx-linux-x64-gnu": "^19.0.3",
     "dpdm": "^3.14.0",
     "lerna": "^7.4.2",
     "typedoc": "^0.24.8"

--- a/packages/aft-core/package.json
+++ b/packages/aft-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-core",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automation Framework for Testing (AFT) package supporting JavaScript unit, integration and functional testing",
   "repository": {
     "type": "git",

--- a/packages/aft-core/src/helpers/ellide.ts
+++ b/packages/aft-core/src/helpers/ellide.ts
@@ -1,5 +1,27 @@
 export type EllipsisLocation = 'beginning' | 'middle' | 'end';
 
+/**
+ * truncates the passed in string if its length exceeds the length specified by
+ * `finalLength` and adds an `ellipsis` at the point of truncation
+ * 
+ * ex:
+ * ```typescript
+ * const original = 'the quick brown fox jumped over the lazy dogs';
+ * ellide(original, 10);              // 'the qui...'
+ * ellide(original, 10, 'beginning'); // '...zy dogs'
+ * ellide(original, 10, 'middle');    // 'the...dogs'
+ * ellide(original, 10, 'end', '_');  // 'the quick_'
+ * ```
+ * @param original the original string to be ellided if over the specified `finalLength`
+ * @param finalLength the maximum length the output string can be (including ellipsis)
+ * @param ellipsisLocation a value of `beginning`, `middle`, or `end` indicating where
+ * the ellipsis will be added and what part of the input string will be truncated
+ * @default end
+ * @param ellipsis the value to use as the ellipsis @default '...'
+ * @returns if the `original` string is over the length specified by `finalLength` then
+ * a truncated string will be returned with the `ellipsis` character(s) at the location
+ * of the truncation as specified by the `ellipsisLocation`
+ */
 export const ellide = function(original: string, finalLength: number, ellipsisLocation: EllipsisLocation = 'end', ellipsis: string = '...'): string {
     if (finalLength >= 5 && original.length > finalLength) {
         switch (ellipsisLocation) {

--- a/packages/aft-core/src/helpers/ellide.ts
+++ b/packages/aft-core/src/helpers/ellide.ts
@@ -23,31 +23,30 @@ export type EllipsisLocation = 'beginning' | 'middle' | 'end';
  * of the truncation as specified by the `ellipsisLocation`
  */
 export const ellide = function(original: string, finalLength: number, ellipsisLocation: EllipsisLocation = 'end', ellipsis: string = '...'): string {
-    if (finalLength >= 5 && original.length > finalLength) {
+    const length = Math.round(finalLength);
+    if (length >= 5 && original.length > length) {
         switch (ellipsisLocation) {
             case 'beginning':
-                const shortenedStr: string = original.substring((original.length - finalLength) + ellipsis.length);
+                const shortenedStr: string = original.substring((original.length - length) + ellipsis.length);
                 return `${ellipsis}${shortenedStr}`;
             case 'middle':
-                const beginningStr: string = original.substring(0, original.length / 2);
-                const endStr: string = original.substring(original.length / 2);
-                let shortenedBeginningStr: string = ellide(beginningStr, (finalLength / 2) - (ellipsis.length / 2), 'end', '');
-                let shortenedEndStr: string = ellide(endStr, (finalLength / 2) - (ellipsis.length / 2), 'beginning', ''); 
+                let beginning = original.substring(0, Math.ceil(length / 2)).split('');
+                let end = original.substring(original.length - Math.ceil(length / 2)).split('');
                 let removeFromBeginning = true;
-                while (shortenedBeginningStr.length + ellipsis.length + shortenedEndStr.length > finalLength) {
+                while (beginning.length + ellipsis.length + end.length > length) {
                     if (removeFromBeginning) {
-                        shortenedBeginningStr = shortenedBeginningStr.substring(0, shortenedBeginningStr.length - 2);
+                        beginning.pop();
                         removeFromBeginning = false;
                     } else {
-                        shortenedEndStr = shortenedEndStr.substring(1, shortenedEndStr.length - 1);
+                        end.shift();
                         removeFromBeginning = true;
                     }
                 }
-                const finalStr = `${shortenedBeginningStr}${ellipsis}${shortenedEndStr}`;
+                const finalStr = `${beginning.join('')}${ellipsis}${end.join('')}`;
                 return finalStr;
             case 'end':
             default:
-                const shortStr = original.substring(0, (finalLength - ellipsis.length));
+                const shortStr = original.substring(0, (length - ellipsis.length));
                 return `${shortStr}${ellipsis}`;
         }
     }

--- a/packages/aft-core/test/helpers/ellide-spec.ts
+++ b/packages/aft-core/test/helpers/ellide-spec.ts
@@ -1,4 +1,4 @@
-import { ellide, rand } from "../../src";
+import { EllipsisLocation, ellide, rand } from "../../src";
 
 describe('ellide', () => {
     it('returns the original string if less than specified length', () => {
@@ -50,4 +50,16 @@ describe('ellide', () => {
         expect(actual.slice(0, 15)).withContext('first part of string should match').toEqual(original.slice(0, 15));
         expect(actual.slice(35, 50)).withContext('last part of string should match').toEqual(original.slice(85, 100));
     });
+
+    const data = [
+        {input: 'the quick brown fox jumped over the lazy dogs', length: 10, location: undefined, ellipsis: undefined, expected: 'the qui...'},
+        {input: 'the quick brown fox jumped over the lazy dogs', length: 10, location: 'beginning', ellipsis: undefined, expected: '...zy dogs'},
+        {input: 'the quick brown fox jumped over the lazy dogs', length: 10, location: 'middle', ellipsis: undefined, expected: 'the...dogs'},
+        {input: 'the quick brown fox jumped over the lazy dogs', length: 10, location: 'end', ellipsis: '_', expected: 'the quick_'},
+    ];
+    for (const d of data) {
+        it(`can process as expected: ${JSON.stringify(d)}`, () => {
+            expect(ellide(d.input, d.length, d.location as EllipsisLocation, d.ellipsis)).toEqual(d.expected);
+        });
+    }
 });

--- a/packages/aft-core/test/helpers/ellide-spec.ts
+++ b/packages/aft-core/test/helpers/ellide-spec.ts
@@ -1,4 +1,4 @@
-import { ellide, EllipsisLocation, rand } from "../../src";
+import { ellide, rand } from "../../src";
 
 describe('ellide', () => {
     it('returns the original string if less than specified length', () => {
@@ -50,4 +50,4 @@ describe('ellide', () => {
         expect(actual.slice(0, 15)).withContext('first part of string should match').toEqual(original.slice(0, 15));
         expect(actual.slice(35, 50)).withContext('last part of string should match').toEqual(original.slice(85, 100));
     });
-})
+});

--- a/packages/aft-jasmine-reporter/package.json
+++ b/packages/aft-jasmine-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-jasmine-reporter",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) Reporter for use with Jasmine Test Framework",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
+    "aft-core": "^12.0.1",
     "jasmine": "^5.1.0"
   },
   "devDependencies": {
@@ -39,8 +39,8 @@
     "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
-    "aft-reporting-filesystem": "^12.0.0",
-    "aft-reporting-html": "^12.0.0",
+    "aft-reporting-filesystem": "^12.0.1",
+    "aft-reporting-html": "^12.0.1",
     "eslint": "^8.57.0",
     "nyc": "^15.1.0",
     "rimraf": "^5.0.1",

--- a/packages/aft-jest-reporter/package.json
+++ b/packages/aft-jest-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-jest-reporter",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) Reporter for use with Jest Test Framework",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
+    "aft-core": "^12.0.1",
     "jest": "^29.7.0"
   },
   "devDependencies": {
@@ -40,8 +40,8 @@
     "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
-    "aft-reporting-filesystem": "^12.0.0",
-    "aft-reporting-html": "^12.0.0",
+    "aft-reporting-filesystem": "^12.0.1",
+    "aft-reporting-html": "^12.0.1",
     "eslint": "^8.57.0",
     "nyc": "^15.1.0",
     "rimraf": "^5.0.1",

--- a/packages/aft-jira/package.json
+++ b/packages/aft-jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-jira",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) package supporting Jira integration for test execution control and logging",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-web-services": "^12.0.0"
+    "aft-web-services": "^12.0.1"
   },
   "devDependencies": {
     "@types/jasmine": "^4.6.4",

--- a/packages/aft-mocha-reporter/package.json
+++ b/packages/aft-mocha-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-mocha-reporter",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) Reporter for use with Mocha Test Framework",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
+    "aft-core": "^12.0.1",
     "mocha": "^10.3.0"
   },
   "devDependencies": {
@@ -40,8 +40,8 @@
     "@types/sinon": "^10.0.20",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
-    "aft-reporting-filesystem": "^12.0.0",
-    "aft-reporting-html": "^12.0.0",
+    "aft-reporting-filesystem": "^12.0.1",
+    "aft-reporting-html": "^12.0.1",
     "chai": "^4.4.1",
     "eslint": "^8.57.0",
     "nyc": "^15.1.0",

--- a/packages/aft-reporting-aws-kinesis-firehose/package.json
+++ b/packages/aft-reporting-aws-kinesis-firehose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-reporting-aws-kinesis-firehose",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) reporting plugin package supporting test reporting to AWS Kinesis Firehose",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
+    "aft-core": "^12.0.1",
     "aws-sdk": "^2.1584.0",
     "date-and-time": "^3.2.0"
   },

--- a/packages/aft-reporting-aws-kinesis-firehose/package.json
+++ b/packages/aft-reporting-aws-kinesis-firehose/package.json
@@ -32,7 +32,8 @@
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
     "aft-core": "^12.0.0",
-    "aws-sdk": "^2.1584.0"
+    "aws-sdk": "^2.1584.0",
+    "date-and-time": "^3.2.0"
   },
   "devDependencies": {
     "@aws-sdk/types": "^3.535.0",

--- a/packages/aft-reporting-aws-kinesis-firehose/src/kinesis-log-record.ts
+++ b/packages/aft-reporting-aws-kinesis-firehose/src/kinesis-log-record.ts
@@ -1,7 +1,13 @@
 import { TestResult, LogMessageData, MachineInfoData } from "aft-core";
 
 export type KinesisLogRecord = {
-    created: number;
+    /**
+     * a `Date` string in the format of `'2024-05-15 15:58:59'`
+     */
+    Created: string;
+    /**
+     * a version string in the format of `'12.1.2'`
+     */
     version: string;
     machineInfo: MachineInfoData;
     log?: LogMessageData;

--- a/packages/aft-reporting-aws-kinesis-firehose/src/kinesis-log-record.ts
+++ b/packages/aft-reporting-aws-kinesis-firehose/src/kinesis-log-record.ts
@@ -1,10 +1,11 @@
 import { TestResult, LogMessageData, MachineInfoData } from "aft-core";
 
+/**
+ * **NOTE:**
+ * > a `@timestamp` field must also be included, but this is specified via
+ * configuration as `KinesisReportingPluginConfig.timestampFieldName`
+ */
 export type KinesisLogRecord = {
-    /**
-     * a `Date` string in the format of `'2024-05-15 15:58:59'`
-     */
-    Created: string;
     /**
      * a version string in the format of `'12.1.2'`
      */

--- a/packages/aft-reporting-aws-kinesis-firehose/src/kinesis-reporting-plugin.ts
+++ b/packages/aft-reporting-aws-kinesis-firehose/src/kinesis-reporting-plugin.ts
@@ -3,6 +3,7 @@ import { Buffer } from "node:buffer";
 import * as AWS from "aws-sdk";
 import * as pkg from "../package.json";
 import { KinesisLogRecord } from "./kinesis-log-record";
+import * as date from "date-and-time";
 
 type SendStrategy = 'logsonly' | 'resultsonly' | 'logsandresults';
 
@@ -160,7 +161,7 @@ export class KinesisReportingPlugin extends ReportingPlugin {
 
     private async _createKinesisLogRecord(logOrResult: LogMessageData | TestResult): Promise<AWS.Firehose.Record> {
         const data: KinesisLogRecord = {
-            created: Date.now(),
+            Created: date.format(new Date(), 'YYYY-MM-DD HH:mm:ss.SSS'),
             version: pkg.version,
             machineInfo: machineInfo.data
         };

--- a/packages/aft-reporting-aws-kinesis-firehose/src/kinesis-reporting-plugin.ts
+++ b/packages/aft-reporting-aws-kinesis-firehose/src/kinesis-reporting-plugin.ts
@@ -1,4 +1,4 @@
-import { ReportingPlugin, LogLevel, TestResult, machineInfo, AftConfig, BuildInfoManager, ReportingPluginConfig, LogMessageData, havingProps } from "aft-core";
+import { ReportingPlugin, LogLevel, TestResult, machineInfo, AftConfig, ReportingPluginConfig, LogMessageData, havingProps } from "aft-core";
 import { Buffer } from "node:buffer";
 import * as AWS from "aws-sdk";
 import * as pkg from "../package.json";
@@ -40,7 +40,6 @@ export class KinesisReportingPluginConfig extends ReportingPluginConfig {
  */
 export class KinesisReportingPlugin extends ReportingPlugin {
     private readonly _logs: Array<AWS.Firehose.Record>;
-    private readonly _buildInfo: BuildInfoManager;
     private readonly _level: LogLevel;
 
     private _client: AWS.Firehose;
@@ -51,13 +50,10 @@ export class KinesisReportingPlugin extends ReportingPlugin {
     
     constructor(aftCfg?: AftConfig, client?: AWS.Firehose) {
         super(aftCfg);
+        const krpc = this.aftCfg.getSection(KinesisReportingPluginConfig);
         this._client = client;
         this._logs = new Array<AWS.Firehose.Record>();
-        this._level = this.aftCfg.getSection(KinesisReportingPluginConfig).logLevel
-            ?? this.aftCfg.logLevel ?? 'warn';
-        if (this.enabled) {
-            this._buildInfo = new BuildInfoManager(this.aftCfg);
-        }
+        this._level = krpc.logLevel ?? this.aftCfg.logLevel ?? 'warn';
     }
 
     async client(): Promise<AWS.Firehose> {

--- a/packages/aft-reporting-aws-kinesis-firehose/test/kinesis-reporting-plugin-spec.ts
+++ b/packages/aft-reporting-aws-kinesis-firehose/test/kinesis-reporting-plugin-spec.ts
@@ -260,7 +260,7 @@ describe('KinesisReportingPlugin', () => {
 
         const logRecord: Firehose.Record = store.get('_send');
         const data: KinesisLogRecord = JSON.parse(logRecord.Data.toString()) as KinesisLogRecord;
-        expect(data.created).toMatch(/[0-9]+/);
+        expect(data.Created).toMatch(/[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}/);
         expect(data.version).toEqual(pkg.version);
         expect(data.machineInfo).toEqual(machineInfo.data);
         expect(data.log).toBeDefined();

--- a/packages/aft-reporting-aws-kinesis-firehose/test/kinesis-reporting-plugin-spec.ts
+++ b/packages/aft-reporting-aws-kinesis-firehose/test/kinesis-reporting-plugin-spec.ts
@@ -260,7 +260,7 @@ describe('KinesisReportingPlugin', () => {
 
         const logRecord: Firehose.Record = store.get('_send');
         const data: KinesisLogRecord = JSON.parse(logRecord.Data.toString()) as KinesisLogRecord;
-        expect(data.Created).toMatch(/[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}/);
+        expect(data['@timestamp']).toMatch(/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\+[0-9]{4}/);
         expect(data.version).toEqual(pkg.version);
         expect(data.machineInfo).toEqual(machineInfo.data);
         expect(data.log).toBeDefined();
@@ -281,7 +281,8 @@ describe('KinesisReportingPlugin', () => {
                 deliveryStream: '%firehose_deliverystream%',
                 logLevel: 'debug',
                 sendStrategy: 'logsandresults',
-                region: 'eu-west-1'
+                region: 'eu-west-1',
+                timestampFieldName: 'Created'
             }
         });
         const plugin: KinesisReportingPlugin = new KinesisReportingPlugin(aftCfg);

--- a/packages/aft-reporting-filesystem/README.md
+++ b/packages/aft-reporting-filesystem/README.md
@@ -17,7 +17,9 @@ this plugin accepts configuration options in the following format:
         "logLevel": "trace",
         "outputPath": "./full/path/or/relative/path/to/directory",
         "includeResults": false,
-        "dateFormat": "YYYY-MM-DD HH:mm:ss.SSS"
+        "dateFormat": "YYYY-MM-DD HH:mm:ss.SSS",
+        "maxFilenameLength": 222,
+        "ellipsisLocation": "middle"
     }
 }
 ```
@@ -25,6 +27,8 @@ this plugin accepts configuration options in the following format:
 - **outputPath** - a `string` with either an absolute path or a relative path from the `process.cwd()` where .log files will be created _(defaults to `path.join(process.cwd(), 'logs')`)_
 - **includeResults** - a `boolean` indicating whether calls to any `ReportingManager.submitResult` function will output the `TestResult` to the .log file _(defaults to `true`)_
 - **dateFormat** - a `string` that can include Date Formatting as outlined at the [date-and-time](https://github.com/knowledgecode/date-and-time#formatdateobj-arg-utc) npm package
+- **maxFilenameLength** - a `number` representing the maximum length log filename allowed before truncation occurs using the `ellide` helper _(defaults to `222`)_
+- **ellipsisLocation** - a `EllipsisLocation` type of `'beginning'`, `'middle'`, or `'end'` that is used if the filename is truncated _(defaults to `'middle'`)_
 
 ## Log Format
 all log files are written using UTF-8 encoding and by default will resemble the following:

--- a/packages/aft-reporting-filesystem/package.json
+++ b/packages/aft-reporting-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-reporting-filesystem",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) reporting plugin package supporting logging to files",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
+    "aft-core": "^12.0.1",
     "date-and-time": "^3.1.1"
   },
   "devDependencies": {

--- a/packages/aft-reporting-filesystem/src/filesystem-reporting-plugin.ts
+++ b/packages/aft-reporting-filesystem/src/filesystem-reporting-plugin.ts
@@ -1,6 +1,6 @@
 import * as process from 'node:process';
 import * as path from "node:path";
-import { AftConfig, convert, ExpiringFileLock, fileio, ReportingPlugin, ReportingPluginConfig, LogLevel, LogMessageData, TestResult, ellide } from "aft-core";
+import { AftConfig, convert, ExpiringFileLock, fileio, ReportingPlugin, ReportingPluginConfig, LogLevel, LogMessageData, TestResult, ellide, EllipsisLocation } from "aft-core";
 import * as date from "date-and-time";
 
 export class FilesystemReportingPluginConfig extends ReportingPluginConfig {
@@ -8,6 +8,8 @@ export class FilesystemReportingPluginConfig extends ReportingPluginConfig {
     outputPath: string = path.join(process.cwd(), 'logs');
     includeResults = true;
     dateFormat = 'YYYY-MM-DD HH:mm:ss.SSS';
+    maxFilenameLength = 222;
+    ellipsisLocation: EllipsisLocation = 'middle';
 }
 
 export class FilesystemReportingPlugin extends ReportingPlugin {
@@ -19,21 +21,22 @@ export class FilesystemReportingPlugin extends ReportingPlugin {
     private readonly _includeResults: boolean;
     private readonly _dateFormat: string;
     private readonly _level: LogLevel;
+    private readonly _maxFilenameLength: number;
+    private readonly _ellipsisLocation: EllipsisLocation;
 
     constructor(aftCfg?: AftConfig) {
         super(aftCfg);
         const fslpc = this.aftCfg.getSection(FilesystemReportingPluginConfig);
-        this._level = fslpc.logLevel ?? this.aftCfg.logLevel
-            ?? 'trace';
-        if (this.enabled) {
-            if (!path.isAbsolute(fslpc.outputPath)) {
-                this._outputPath = path.join(process.cwd(), fslpc.outputPath);
-            } else {
-                this._outputPath = fslpc.outputPath;
-            }
-            this._includeResults = fslpc.includeResults ?? true;
-            this._dateFormat = fslpc.dateFormat ?? 'YYYY-MM-DD HH:mm:ss.SSS';
+        this._level = fslpc.logLevel ?? this.aftCfg.logLevel ?? 'trace';
+        if (!path.isAbsolute(fslpc.outputPath)) {
+            this._outputPath = path.join(process.cwd(), fslpc.outputPath);
+        } else {
+            this._outputPath = fslpc.outputPath;
         }
+        this._includeResults = fslpc.includeResults ?? true;
+        this._dateFormat = fslpc.dateFormat ?? 'YYYY-MM-DD HH:mm:ss.SSS';
+        this._maxFilenameLength = fslpc.maxFilenameLength ?? 222;
+        this._ellipsisLocation = fslpc.ellipsisLocation ?? 'middle';
     }
 
     override initialise = async (logName: string): Promise<void> => { // eslint-disable-line no-unused-vars
@@ -80,7 +83,8 @@ export class FilesystemReportingPlugin extends ReportingPlugin {
     private _appendToFile(logObj: LogMessageData): void {
         if (LogLevel.toValue(logObj.level) >= LogLevel.toValue(this.logLevel) && logObj.level !== 'none') {
             const filename = convert.toSafeString(logObj.name);
-            const fullPath = path.join(this._outputPath, `${filename}.log`);
+            const filenameShortened = ellide(filename, this._maxFilenameLength, this._ellipsisLocation);
+            const fullPath = path.join(this._outputPath, `${filenameShortened}.log`);
             const lock = new ExpiringFileLock(fullPath, this.aftCfg);
             try {
                 fileio.append(fullPath, `${this._format(logObj)}\n`);

--- a/packages/aft-reporting-html/package.json
+++ b/packages/aft-reporting-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-reporting-html",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) package that creates a HTML results file as a Reporting Plugin",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -44,6 +44,6 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "aft-core": "^12.0.0"
+    "aft-core": "^12.0.1"
   }
 }

--- a/packages/aft-reporting-html/src/templates/html-template.ts
+++ b/packages/aft-reporting-html/src/templates/html-template.ts
@@ -198,8 +198,8 @@ function addResult(result) {
 <div class="card card-info" name="\${result.description}-ps-results">
     <div class="card-header p-0 bg-secondary d-flex justify-content-between flex-row text-light" onclick="toggleCard('\${result.description}-ps-results');">
         <div class="p-1"><i class="bi bi-dash" aria-hidden="true"></i></div>
-        <div class="p-1 flex-grow-1"><span class="badge badge-default">Description:</span> \${result.description}</div>
-        <div class="p-1"><span class="badge rounded-pill bg-primary totalTests">\${passing + failing + notRun}</span> <span class="badge bg-success totalTestsPassing">\${passing}</span> <span class="badge bg-danger totalTestsFailing">\${failing}</span> <span class="badge bg-warning totalTestsNotRun">\${notRun}</span></div>
+        <div class="p-1 flex-grow-1 breakWrap"><span class="badge badge-default">Description:</span> \${result.description}</div>
+        <div class="p-1 noWrap"><span class="badge rounded-pill bg-primary totalTests">\${passing + failing + notRun}</span> <span class="badge bg-success totalTestsPassing">\${passing}</span> <span class="badge bg-danger totalTestsFailing">\${failing}</span> <span class="badge bg-warning totalTestsNotRun">\${notRun}</span></div>
     </div>
     <div class="card-body p-0" name="body-\${result.description}-ps-results"></div>
 </div>
@@ -262,7 +262,7 @@ function addTests(container, tests) {
             <td class="status">
                 <span class="badge badge-\${statusClass}">\${result.status}</span>
             </td>
-            <td class="logs">
+            <td class="logs breakWrap">
                 \${result.logs.join('<br />')}
             </td>
         </tr>
@@ -308,6 +308,8 @@ div.vertical-align {
     height:50px;
 }
 .breakWrap {
+    max-width: 100dvw;
+    overflow-wrap: break-word;
     -ms-word-break: break-all;
     /* Be VERY careful with this, breaks normal words wh_erever */
     word-break: break-all;
@@ -317,6 +319,10 @@ div.vertical-align {
     -webkit-hyphens: auto;
     -moz-hyphens: auto;
     hyphens: auto;
+}
+.noWrap {
+    max-width: 100dvw;
+    white-space: nowrap;
 }
 </style>
 </head>

--- a/packages/aft-reporting-html/src/templates/tmp.html
+++ b/packages/aft-reporting-html/src/templates/tmp.html
@@ -194,8 +194,8 @@ function addResult(result) {
 <div class="card card-info" name="${result.description}-ps-results">
     <div class="card-header p-0 bg-secondary d-flex justify-content-between flex-row text-light" onclick="toggleCard('${result.description}-ps-results');">
         <div class="p-1"><i class="bi bi-dash" aria-hidden="true"></i></div>
-        <div class="p-1 flex-grow-1"><span class="badge badge-default">Description:</span> ${result.description}</div>
-        <div class="p-1"><span class="badge rounded-pill bg-primary totalTests">${passing + failing + notRun}</span> <span class="badge bg-success totalTestsPassing">${passing}</span> <span class="badge bg-danger totalTestsFailing">${failing}</span> <span class="badge bg-warning totalTestsNotRun">${notRun}</span></div>
+        <div class="p-1 flex-grow-1 breakWrap"><span class="badge badge-default">Description:</span> ${result.description}</div>
+        <div class="p-1 noWrap"><span class="badge rounded-pill bg-primary totalTests">${passing + failing + notRun}</span> <span class="badge bg-success totalTestsPassing">${passing}</span> <span class="badge bg-danger totalTestsFailing">${failing}</span> <span class="badge bg-warning totalTestsNotRun">${notRun}</span></div>
     </div>
     <div class="card-body p-0" name="body-${result.description}-ps-results"></div>
 </div>
@@ -258,7 +258,7 @@ function addTests(container, tests) {
             <td class="status">
                 <span class="badge badge-${statusClass}">${result.status}</span>
             </td>
-            <td class="logs">
+            <td class="logs breakWrap">
                 ${result.logs.join('<br />')}
             </td>
         </tr>
@@ -304,6 +304,8 @@ div.vertical-align {
     height:50px;
 }
 .breakWrap {
+    max-width: 100dvw;
+    overflow-wrap: break-word;
     -ms-word-break: break-all;
     /* Be VERY careful with this, breaks normal words wh_erever */
     word-break: break-all;
@@ -313,6 +315,10 @@ div.vertical-align {
     -webkit-hyphens: auto;
     -moz-hyphens: auto;
     hyphens: auto;
+}
+.noWrap {
+    max-width: 100dvw;
+    white-space: nowrap;
 }
 </style>
 </head>
@@ -354,8 +360,8 @@ google.load("visualization", "1", {packages:["corechart"]});
 google.setOnLoadCallback(drawChart);
 initialise([
     {description: 'foo_is_my_name', tests: [{created: Date.now(), testId: 'C1234', status: 'passed', logs: ['this is log line 1', 'this is log line 2']}]},
-    {description: 'bar_is_my_name', tests: [{created: Date.now(), testId: 'C2345', status: 'failed', logs: ['this is log line 1']}]},
-    {description: 'baz_is_my_name', tests: [{created: Date.now(), status: 'untested', logs: []}, {created: Date.now(), testId: 'C3456', status: 'passed', logs: ['this is log line 1']}]}
+    {description: 'bar_is_my_name', tests: [{created: Date.now(), testId: 'C2345', status: 'failed', logs: ['_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1_this_is_log_line_1']}]},
+    {description: '_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name_baz_is_my_name', tests: [{created: Date.now(), status: 'untested', logs: []}, {created: Date.now(), testId: 'C3456', status: 'passed', logs: ['this is log line 1']}]}
 ]);
 </script>
 </html>

--- a/packages/aft-testrail/package.json
+++ b/packages/aft-testrail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-testrail",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) package supporting TestRail integration for test execution control and logging",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-web-services": "^12.0.0"
+    "aft-web-services": "^12.0.1"
   },
   "devDependencies": {
     "@types/jasmine": "^4.6.4",

--- a/packages/aft-ui-selenium/package.json
+++ b/packages/aft-ui-selenium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-ui-selenium",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) package supporting UI testing in browsers",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-ui": "^12.0.0",
+    "aft-ui": "^12.0.1",
     "selenium-webdriver": "^4.18.1"
   },
   "devDependencies": {

--- a/packages/aft-ui-webdriverio/package.json
+++ b/packages/aft-ui-webdriverio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-ui-webdriverio",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) package supporting UI testing in mobile apps with support for BrowserStack, Sauce Labs and Local Appium",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-ui": "^12.0.0",
+    "aft-ui": "^12.0.1",
     "webdriverio": "^8.35.1"
   },
   "devDependencies": {

--- a/packages/aft-ui/package.json
+++ b/packages/aft-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-ui",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) core package supporting UI testing via plugins",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0"
+    "aft-core": "^12.0.1"
   },
   "devDependencies": {
     "@types/jasmine": "^4.6.4",

--- a/packages/aft-vitest-reporter/package.json
+++ b/packages/aft-vitest-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-vitest-reporter",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) Reporter for use with Vite Test Framework (vitest)",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
+    "aft-core": "^12.0.1",
     "vitest": "^1.5.0"
   },
   "devDependencies": {
@@ -39,8 +39,8 @@
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
     "@vitest/coverage-istanbul": "^1.5.0",
-    "aft-reporting-filesystem": "^12.0.0",
-    "aft-reporting-html": "^12.0.0",
+    "aft-reporting-filesystem": "^12.0.1",
+    "aft-reporting-html": "^12.0.1",
     "eslint": "^8.57.0",
     "nyc": "^15.1.0",
     "rimraf": "^5.0.1",

--- a/packages/aft-web-services/package.json
+++ b/packages/aft-web-services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aft-web-services",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Automated Functional Testing (AFT) module for testing web services over HTTP and HTTPS",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bicarbon8/automated-functional-testing#readme",
   "dependencies": {
-    "aft-core": "^12.0.0",
+    "aft-core": "^12.0.1",
     "form-data": "^4.0.0",
     "xmldoc": "^1.3.0"
   },


### PR DESCRIPTION
* makes Firehose timestamp field name and format configurable to fix delivery to Opensearch / Elasticsearch instances
* makes log file name length configurable with a default limit of 222 to prevent errors trying to write long names
* fixes display in html results for long description strings and long log lines